### PR TITLE
fix #12: add Makefile for common dev tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build server client migrate reset-db
+
+# Build all packages in dependency order
+build:
+	pnpm --filter @5d/types build
+	pnpm --filter @5d/engine build
+	pnpm --filter @5d/stub build
+
+# Run the server in dev (watch) mode
+server: build
+	pnpm --filter @5d/server dev
+
+# Run the client in dev mode
+client:
+	pnpm --filter @5d/client dev
+
+# Run DB migration
+migrate:
+	pnpm --filter @5d/server db:migrate
+
+# Wipe SQLite DB and re-migrate
+reset-db:
+	rm -f apps/server/data.db apps/server/data.db-shm apps/server/data.db-wal
+	pnpm --filter @5d/server db:migrate


### PR DESCRIPTION
Adds a `Makefile` at the repo root with targets:

- `make build` — build types → engine → stub in dependency order
- `make server` — build then run server in dev (watch) mode
- `make client` — run client dev mode
- `make migrate` — run DB migration
- `make reset-db` — wipe SQLite files and re-migrate

No code changes. Closes #12