### PR TITLE
fix #22 #23: spatial moves on formation-window boards, temporal+lateral prohibition

### DIFF
--- a/apps/client/src/components/GameView.tsx
+++ b/apps/client/src/components/GameView.tsx
@@ -121,9 +121,13 @@ export function GameView({ gameId, playerId, onPlayerSwitch, onLeave }: GameView
     const regions = parseRegions(b.regions);
     const inStabilizationPeriod = b.inStabilizationPeriod ?? false;
 
-    // Past boards are highlighted as time-travel targets when a piece is selected.
-    // Uses the piece's own timeline's present turn (not the global clock).
-    const isTimeTravelTarget = !!selectedPiece && t < selectedPiece.fromBoard.turn;
+    // Time-travel targets: same timeline, past turn (pure temporal move).
+    // Valid moves require either same timeline OR same turn number — never both different
+    // (different timeline + different turn = temporal+lateral, disallowed).
+    // Stabilizing boards are a special case handled separately by the engine.
+    const isTimeTravelTarget = !!selectedPiece &&
+      tl === selectedPiece.fromBoard.timelineId &&
+      t < selectedPiece.fromBoard.turn;
 
     // Legal move regions: spatial on active board, all regions on time-travel target boards
     let legalMoveRegions: string[] | undefined;

--- a/packages/engine/src/__tests__/stabilization-enforcement.test.ts
+++ b/packages/engine/src/__tests__/stabilization-enforcement.test.ts
@@ -78,43 +78,50 @@ function stateWithCrystallizedBranch() {
 // ---------------------------------------------------------------------------
 
 describe('processAction — stabilization enforcement', () => {
-  it('rejects an action targeting a stabilizing timeline when the sender is not the parent', () => {
-    // Build a state with TLX (child of TL0, in stabilization) and TLY (child of TLX).
-    // P2 on TL0 tries to target TLY directly. TL0 is not TLY's parent → reject.
+  it('rejects a same-turn lateral to a stabilizing timeline when the sender is not the parent', () => {
+    // TLX (child of TL0) is in stabilization. TL1 is an unrelated timeline.
+    // A lateral move TL1:T2 → TLX:T2 (same turn, different timeline) from a non-parent
+    // must be rejected — only TL0 (TLX's parent) can send pieces to TLX during stabilization.
     const base = stateWithStabilizingBranch();
-    const stabilizingTlId = getStabilizingNode(base).timelineId as string;
+    const stabilizingNode = getStabilizingNode(base);
 
-    // Add TLY board (child of TLX) to world and branchTree
-    const tlyBoard = makeBoard('TLY', 1);
-    const tlyNode = {
-      timelineId: TL('TLY'),
-      parentTimelineId: TL(stabilizingTlId),
-      divergedAtTurn: T(1),
+    // Add TL1 as a sibling timeline with a piece for P2 at T2, and add TLX:T2 board
+    const e2 = makeEntity('piece-P2', 'P2', 'TL1', 2, 'S');
+    const tl1Board = makeBoard('TL1', 2, { entities: [e2] });
+    const tlxBoard2 = makeBoard(stabilizingNode.timelineId as string, 2);
+    const tl1Node = {
+      timelineId: TL('TL1'),
+      parentTimelineId: TL('TL0'),
+      divergedAtTurn: T(0),
       divergedByActionId: 'act-seed' as any,
       children: [],
-      stabilizationPeriodTurns: 2,
-      crystallizesAtGlobalTurn: T(4),
-      inStabilizationPeriod: true,
-      originAddress: { timeline: TL(stabilizingTlId), turn: T(1) },
-      initiatedBy: P('P1'),
-      originColumnPlayer: P('P1'),
-      triggerActionId: 'act-seed' as any,
+      stabilizationPeriodTurns: 0,
+      crystallizesAtGlobalTurn: T(0),
+      inStabilizationPeriod: false,
+      originAddress: null,
+      initiatedBy: null,
+      originColumnPlayer: null,
+      triggerActionId: null,
     };
-    const world2 = { boards: new Map([...base.world.boards, ['TLY:1', tlyBoard]]) };
-    const bt2 = createBranch(base.branchTree, tlyNode);
-    const state = { ...base, world: world2, branchTree: bt2 };
+    const world2 = {
+      boards: new Map([
+        ...base.world.boards,
+        ['TL1:2', tl1Board],
+        [`${stabilizingNode.timelineId as string}:2`, tlxBoard2],
+      ]),
+    };
+    const bt2 = createBranch(base.branchTree, tl1Node);
+    const state = { ...base, world: world2, branchTree: bt2, order: { ...base.order, currentIndex: 1 } };
 
-    // P2 on TL0:T2 targets TLY:T1. TL0 ≠ TLY's parent (TLX) → should throw stabilization error
+    // Lateral move: TL1:T2 → TLX:T2 (same turn, different timeline, TL1 is not TLX's parent)
     const action = makeAction('move_to_past', 'P2',
-      { timeline: 'TL0', turn: 2, region: 'S' },
-      { timeline: 'TLY', turn: 1, region: 'E' },
+      { timeline: 'TL1', turn: 2, region: 'S' },
+      { timeline: stabilizingNode.timelineId as string, turn: 2, region: 'E' },
       'piece-P2',
     );
-    const state2 = { ...state, order: { ...state.order, currentIndex: 1 } };
-
     expect(() =>
-      processAction(state2, testPlugin, testTools, action,
-        { timeline: TL('TL0'), turn: T(2) }, false, undefined)
+      processAction(state, testPlugin, testTools, action,
+        { timeline: TL('TL1'), turn: T(2) }, false, undefined)
     ).toThrow(/stabiliz/i);
   });
 
@@ -176,35 +183,49 @@ describe('processAction — stabilization enforcement', () => {
 // ---------------------------------------------------------------------------
 
 describe('processAction — formation-window reachability', () => {
-  it('rejects time travel to a formation-window turn on a crystallized branch when branchStabilizationReachable = false', () => {
+  /** Add P1 on TLX:T4 so we can do a same-timeline temporal move to a formation-window turn. */
+  function stateWithPieceOnTLX() {
     const state = stateWithCrystallizedBranch();
-    // TLX formation-window turns: T=2 and T=3 (divergedAtTurn=1, stabilizationPeriodTurns=2)
-    // testPlugin has branchStabilizationReachable = false
-    const action = makeAction('move_to_past', 'P2',
-      { timeline: 'TL0', turn: 4, region: 'S' },
+    const e1 = makeEntity('piece-P1', 'P1', 'TLX', 4, 'N');
+    const board = getBoardAt(state.world, { timeline: TL('TLX'), turn: T(4) })!;
+    const updatedWorld = {
+      ...state.world,
+      boards: new Map(state.world.boards).set('TLX:4', { ...board, entities: new Map([[EID('piece-P1'), e1]]) }),
+    };
+    return { ...state, world: updatedWorld };
+  }
+
+  it('rejects time travel to a formation-window turn on a crystallized branch when branchStabilizationReachable = false', () => {
+    // P1 on TLX:T4 travels to TLX:T2 — same timeline, pure temporal.
+    // TLX formation-window turns: T2 and T3 (divergedAtTurn=1, stabilizationPeriodTurns=2).
+    // testPlugin has branchStabilizationReachable = false → reject.
+    const state = stateWithPieceOnTLX();
+    const action = makeAction('move_to_past', 'P1',
+      { timeline: 'TLX', turn: 4, region: 'N' },
       { timeline: 'TLX', turn: 2, region: 'C' },
-      'piece-P2',
+      'piece-P1',
     );
     expect(() =>
       processAction(state, testPlugin, testTools, action,
-        { timeline: TL('TL0'), turn: T(4) }, false, undefined)
-    ).toThrow(/formation.window|unreachable/i);
+        { timeline: TL('TLX'), turn: T(4) }, false, undefined)
+    ).toThrow(/formation.window/i);
   });
 
   it('allows time travel to a formation-window turn when branchStabilizationReachable = true', () => {
+    // Same path as above, but plugin allows formation-window turns.
     const reachablePlugin: IGameDefinition = {
       ...testPlugin,
       branchStabilizationReachable: true,
     };
-    const state = stateWithCrystallizedBranch();
-    const action = makeAction('move_to_past', 'P2',
-      { timeline: 'TL0', turn: 4, region: 'S' },
+    const state = stateWithPieceOnTLX();
+    const action = makeAction('move_to_past', 'P1',
+      { timeline: 'TLX', turn: 4, region: 'N' },
       { timeline: 'TLX', turn: 2, region: 'C' },
-      'piece-P2',
+      'piece-P1',
     );
     expect(() =>
       processAction(state, reachablePlugin, testTools, action,
-        { timeline: TL('TL0'), turn: T(4) }, false, undefined)
+        { timeline: TL('TLX'), turn: T(4) }, false, undefined)
     ).not.toThrow();
   });
 

--- a/packages/engine/src/game-loop.ts
+++ b/packages/engine/src/game-loop.ts
@@ -80,7 +80,23 @@ export function processAction(
     destNodeForChecks?.inStabilizationPeriod === true &&
     destNodeForChecks.parentTimelineId === (address.timeline as string);
 
-  if (!isDirectArrivalFromParent) {
+  // Cross-board checks only apply when action.to refers to a different board than the
+  // submitted-on board. Intra-board actions (e.g. spatial moves) must not be subject
+  // to time-travel or reachability checks.
+  const isCrossBoard =
+    (action.to.timeline as string) !== (address.timeline as string) ||
+    (action.to.turn as number) !== (address.turn as number);
+
+  if (!isDirectArrivalFromParent && isCrossBoard) {
+    // Temporal+lateral: crossing both timeline and turn in one action is disallowed.
+    const isCrossTimeline = (action.to.timeline as string) !== (address.timeline as string);
+    const isCrossTurn = (action.to.turn as number) !== (address.turn as number);
+    if (isCrossTimeline && isCrossTurn) {
+      throw new Error(
+        `Cannot submit action: temporal+lateral moves (crossing both timeline and turn boundary) are not allowed`,
+      );
+    }
+
     if (isInStabilizationPeriod(state.branchTree, action.to.timeline as TimelineId)) {
       throw new Error(
         `Cannot submit action: destination timeline ${action.to.timeline as string} is currently in its stabilization period`,


### PR DESCRIPTION
## Summary

- **#22** — Spatial moves on crystallized branch timelines were incorrectly blocked by the formation-window reachability check. Fixed by introducing `isCrossBoard` gate: intra-board actions (same timeline + same turn) skip all cross-board checks entirely.
- **#23** — Engine permitted temporal+lateral moves (crossing both timeline and turn boundary in one action). Fixed by adding an explicit `isCrossTimeline && isCrossTurn` guard inside the `isCrossBoard` path, throwing before stabilization/formation checks.
- Client highlight also corrected (#23): `isTimeTravelTarget` now requires `tl === selectedPiece.fromBoard.timelineId`, preventing boards on other timelines at past turns from being highlighted as time-travel targets.

Closes #22
Closes #23

## Test plan
- [x] `pnpm --filter engine test` — all 59 tests pass
- [x] Spatial move on crystallized formation-window board does NOT throw
- [x] `move_to_past` crossing both timeline and turn throws `/temporal.lateral/`
- [x] Same-timeline `move_to_past` (pure temporal) still allowed