### PR TITLE
fix #24: formation window off-by-one blocks post-crystallization time travel

### DIFF
--- a/packages/engine/src/__tests__/stabilization-enforcement.test.ts
+++ b/packages/engine/src/__tests__/stabilization-enforcement.test.ts
@@ -42,7 +42,7 @@ function getStabilizingNode(state: ReturnType<typeof stateWithStabilizingBranch>
 /**
  * Manually build a state where TLX is already crystallized (inStabilizationPeriod = false).
  * TL0 at T=4, TLX branched from TL0:T=1, stabilizationPeriodTurns=2.
- * Formation-window turns for TLX: T=2 and T=3.
+ * Formation-window turns for TLX: T=2 only (divergedAtTurn+1..divergedAtTurn+stabilizationPeriodTurns-1).
  */
 function stateWithCrystallizedBranch() {
   const e2 = makeEntity('piece-P2', 'P2', 'TL0', 4, 'S');
@@ -197,7 +197,7 @@ describe('processAction — formation-window reachability', () => {
 
   it('rejects time travel to a formation-window turn on a crystallized branch when branchStabilizationReachable = false', () => {
     // P1 on TLX:T4 travels to TLX:T2 — same timeline, pure temporal.
-    // TLX formation-window turns: T2 and T3 (divergedAtTurn=1, stabilizationPeriodTurns=2).
+    // TLX formation-window turns: T2 only (divergedAtTurn=1, stabilizationPeriodTurns=2 → window is T2..T2).
     // testPlugin has branchStabilizationReachable = false → reject.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
@@ -230,7 +230,7 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('allows time travel to a non-formation-window turn on a crystallized branch', () => {
-    // TLX:T=4 is outside the formation window (formation ends at T=3)
+    // TLX:T=4 is outside the formation window (formation ends at T=2 after fix #24)
     const state = stateWithCrystallizedBranch();
     const e1 = makeEntity('piece-P1', 'P1', 'TL0', 4, 'N');
     const board = getBoardAt(state.world, { timeline: TL('TL0'), turn: T(4) })!;
@@ -254,6 +254,26 @@ describe('processAction — formation-window reachability', () => {
       thrownMsg = (e as Error).message;
     }
     expect(thrownMsg).not.toMatch(/formation.window|unreachable/i);
+  });
+
+  it('allows time travel to the first post-crystallization turn (bug #24)', () => {
+    // divergedAtTurn=1, stabilizationPeriodTurns=2 → correct formation window is T2 only.
+    // T3 is the first board created AFTER crystallization and must be reachable.
+    // The buggy formula incorrectly includes T3 in the formation window.
+    const state = stateWithPieceOnTLX();
+    const action = makeAction('move_to_past', 'P1',
+      { timeline: 'TLX', turn: 4, region: 'N' },
+      { timeline: 'TLX', turn: 3, region: 'C' },
+      'piece-P1',
+    );
+    let thrownMsg = '';
+    try {
+      processAction(state, testPlugin, testTools, action,
+        { timeline: TL('TLX'), turn: T(4) }, false, undefined);
+    } catch (e) {
+      thrownMsg = (e as Error).message;
+    }
+    expect(thrownMsg).not.toMatch(/formation.window/i);
   });
 });
 

--- a/packages/engine/src/branch-tree.ts
+++ b/packages/engine/src/branch-tree.ts
@@ -115,7 +115,13 @@ export function isFormationWindowReachable(
 
   const isRoot = node.parentTimelineId === null;
   const formationStart = isRoot ? 1 : (node.divergedAtTurn as number) + 1;
-  const formationEnd = formationStart + node.stabilizationPeriodTurns - 1;
+  // Root: formation window is T1..stabilizationPeriodTurns (n boards created during stabilization).
+  // Branch: advanceAllTimelines runs AFTER crystallizeDueWindows on the final turn, so only
+  // (stabilizationPeriodTurns - 1) boards are created during stabilization. The last advance is
+  // post-crystallization. Formation window = (divergedAtTurn+1)..(divergedAtTurn+stabilizationPeriodTurns-1).
+  const formationEnd = isRoot
+    ? formationStart + node.stabilizationPeriodTurns - 1
+    : (node.divergedAtTurn as number) + node.stabilizationPeriodTurns - 1;
 
   if ((turn as number) < formationStart || (turn as number) > formationEnd) {
     return true; // outside formation window — always reachable


### PR DESCRIPTION
## Summary

`isFormationWindowReachable` in `branch-tree.ts` computed:

```
formationEnd = formationStart + stabilizationPeriodTurns - 1
```

For non-root timelines, `formationStart = divergedAtTurn + 1`, so this gives `divergedAtTurn + stabilizationPeriodTurns` — one too many.

The server calls `advanceAllTimelines` **after** `crystallizeDueWindows`, so the last board advance is post-crystallization. With 2 players and `divergedAtTurn=1`, the formation window is T2 only; T3 is the first post-crystallization board and must be reachable.

**Fix:** branch timelines use `divergedAtTurn + stabilizationPeriodTurns - 1` for `formationEnd`. Root formula is unchanged.

Closes #24

## Test plan
- [x] New test: `allows time travel to the first post-crystallization turn (bug #24)` — travels TLX:T4→TLX:T3, expects no formation-window error
- [x] `pnpm --filter engine test` — 60 tests pass
- [x] `pnpm --filter engine typecheck` — clean