### PR TITLE
fix #29: formation window start excludes divergedAtTurn board

### DIFF
--- a/packages/engine/src/__tests__/stabilization-enforcement.test.ts
+++ b/packages/engine/src/__tests__/stabilization-enforcement.test.ts
@@ -42,7 +42,7 @@ function getStabilizingNode(state: ReturnType<typeof stateWithStabilizingBranch>
 /**
  * Manually build a state where TLX is already crystallized (inStabilizationPeriod = false).
  * TL0 at T=4, TLX branched from TL0:T=1, stabilizationPeriodTurns=2.
- * Formation-window turns for TLX: T=2 only (divergedAtTurn+1..divergedAtTurn+stabilizationPeriodTurns-1).
+ * Formation-window turns for TLX: T=1..T=2 (divergedAtTurn..divergedAtTurn+stabilizationPeriodTurns-1).
  */
 function stateWithCrystallizedBranch() {
   const e2 = makeEntity('piece-P2', 'P2', 'TL0', 4, 'S');
@@ -197,7 +197,7 @@ describe('processAction — formation-window reachability', () => {
 
   it('rejects time travel to a formation-window turn on a crystallized branch when branchStabilizationReachable = false', () => {
     // P1 on TLX:T4 travels to TLX:T2 — same timeline, pure temporal.
-    // TLX formation-window turns: T2 only (divergedAtTurn=1, stabilizationPeriodTurns=2 → window is T2..T2).
+    // TLX formation-window turns: T1..T2 (divergedAtTurn=1, stabilizationPeriodTurns=2 → window is T1..T2).
     // testPlugin has branchStabilizationReachable = false → reject.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
@@ -230,7 +230,7 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('allows time travel to a non-formation-window turn on a crystallized branch', () => {
-    // TLX:T=4 is outside the formation window (formation ends at T=2 after fix #24)
+    // TLX:T=4 is outside the formation window (window is T1..T2 after fixes #24/#29)
     const state = stateWithCrystallizedBranch();
     const e1 = makeEntity('piece-P1', 'P1', 'TL0', 4, 'N');
     const board = getBoardAt(state.world, { timeline: TL('TL0'), turn: T(4) })!;
@@ -256,10 +256,25 @@ describe('processAction — formation-window reachability', () => {
     expect(thrownMsg).not.toMatch(/formation.window|unreachable/i);
   });
 
+  it('rejects time travel to divergedAtTurn itself (bug #29)', () => {
+    // divergedAtTurn=1 is the origin board — created when the branch was made.
+    // It is part of the formation period and must be unreachable when branchStabilizationReachable=false.
+    // The buggy formationStart=divergedAtTurn+1 lets this board through.
+    const state = stateWithPieceOnTLX();
+    const action = makeAction('move_to_past', 'P1',
+      { timeline: 'TLX', turn: 4, region: 'N' },
+      { timeline: 'TLX', turn: 1, region: 'C' },
+      'piece-P1',
+    );
+    expect(() =>
+      processAction(state, testPlugin, testTools, action,
+        { timeline: TL('TLX'), turn: T(4) }, false, undefined)
+    ).toThrow(/formation.window/i);
+  });
+
   it('allows time travel to the first post-crystallization turn (bug #24)', () => {
-    // divergedAtTurn=1, stabilizationPeriodTurns=2 → correct formation window is T2 only.
+    // divergedAtTurn=1, stabilizationPeriodTurns=2 → formation window is T1..T2.
     // T3 is the first board created AFTER crystallization and must be reachable.
-    // The buggy formula incorrectly includes T3 in the formation window.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TLX', turn: 4, region: 'N' },

--- a/packages/engine/src/branch-tree.ts
+++ b/packages/engine/src/branch-tree.ts
@@ -114,11 +114,15 @@ export function isFormationWindowReachable(
   if (node.inStabilizationPeriod) return false; // still stabilizing
 
   const isRoot = node.parentTimelineId === null;
-  const formationStart = isRoot ? 1 : (node.divergedAtTurn as number) + 1;
-  // Root: formation window is T1..stabilizationPeriodTurns (n boards created during stabilization).
-  // Branch: advanceAllTimelines runs AFTER crystallizeDueWindows on the final turn, so only
-  // (stabilizationPeriodTurns - 1) boards are created during stabilization. The last advance is
-  // post-crystallization. Formation window = (divergedAtTurn+1)..(divergedAtTurn+stabilizationPeriodTurns-1).
+  // Formation window starts at divergedAtTurn (the origin board, copied at branch creation)
+  // because that board was also created during the unstable formation period.
+  // Root has no divergedAtTurn so its window starts at T1.
+  const formationStart = isRoot ? 1 : (node.divergedAtTurn as number);
+  // Formation window is exactly stabilizationPeriodTurns wide:
+  //   root:   T1 .. stabilizationPeriodTurns
+  //   branch: divergedAtTurn .. divergedAtTurn + stabilizationPeriodTurns - 1
+  // advanceAllTimelines fires AFTER crystallizeDueWindows on the closing turn, so the last
+  // advance produces the first post-crystallization board (outside the window).
   const formationEnd = isRoot
     ? formationStart + node.stabilizationPeriodTurns - 1
     : (node.divergedAtTurn as number) + node.stabilizationPeriodTurns - 1;


### PR DESCRIPTION
## Summary

The origin board of a branch timeline (at \`divergedAtTurn\`) is created during the unstable formation period — it is a copy of the parent board made at the moment of branching. It should be part of the formation window and unreachable (when \`branchStabilizationReachable=false\`), just like the boards advanced during stabilization.

**Bug:** \`formationStart\` for non-root timelines used \`divergedAtTurn + 1\`, letting the origin board slip through the check.

**Symptom:** On a crystallized branch with \`divergedAtTurn=5\`, \`stabilizationPeriodTurns=2\`:
- T7 → T6: correctly blocked (formation window)  
- T7 → T5: incorrectly allowed (origin board, should also be blocked)

**Fix:** \`formationStart = divergedAtTurn\` (not \`+1\`). Formation window is now exactly \`stabilizationPeriodTurns\` wide for both root and branch timelines.

Closes #29

## Test plan
- [x] New test: rejects time travel to `divergedAtTurn` (T1) on crystallized branch — throws `/formation.window/`
- [x] Existing tests unchanged: T2 still blocked, T3 (post-cryst) still reachable
- [x] 61 tests pass, typecheck clean