### PR TITLE
feat #26: timeline naming (TL1/TL2), newest-child-first ordering, SVG branch lines

### DIFF
--- a/apps/client/src/components/BoardGrid.tsx
+++ b/apps/client/src/components/BoardGrid.tsx
@@ -28,18 +28,45 @@ export interface BoardCell {
   selectedPieceRegion?: string;
 }
 
+export interface BranchInfo {
+  timelineId: string;
+  parentTimelineId: string | null;
+  divergedAtTurn: number | null;
+}
+
 export interface BoardGridProps {
   cells: BoardCell[];
   maxTurn: number;
   timelines: string[];
+  branchInfo?: BranchInfo[];
   selectedCell?: { timelineId: string; turn: number } | null;
   onCellClick?: (cell: BoardCell) => void;
   onPieceClick?: (pieceId: string, cell: BoardCell) => void;
   onRegionClick?: (regionId: string, cell: BoardCell) => void;
 }
 
-const ROW_HEIGHT = 116; // px — 7rem grid rows + 1px gap
-const COL_WIDTH = 116;  // px — minmax(7rem, 1fr) approximation
+// Grid geometry constants (must match CSS below).
+// Cell size: 7rem = 112px. Row gap: 12px (gap-y-3). Col gap: 4px (gap-x-1). Padding: 8px (p-2).
+// Header row: 1.5rem = 24px. Label col: 4rem = 64px.
+const CELL_W = 112;
+const CELL_H = 112;
+const GAP_X = 4;
+const GAP_Y = 12;
+const PAD = 8;
+const HEADER_H = 24;
+const LABEL_W = 64;
+const COL_STRIDE = CELL_W + GAP_X; // 116
+const ROW_STRIDE = CELL_H + GAP_Y; // 124
+
+/** Pixel centre of cell at (rowIndex, turnIndex), both 0-based. */
+function cellCenter(row: number, col: number) {
+  return {
+    x: PAD + LABEL_W + GAP_X + col * COL_STRIDE + CELL_W / 2,
+    y: PAD + HEADER_H + GAP_Y + row * ROW_STRIDE + CELL_H / 2,
+  };
+}
+
+const COL_WIDTH = COL_STRIDE; // kept for scroll helper
 
 // Stable player→color mapping by hashing the player ID
 const PALETTE = ['#3b82f6', '#ef4444', '#22c55e', '#eab308', '#a855f7', '#f97316', '#06b6d4'];
@@ -53,6 +80,7 @@ export function BoardGrid({
   cells,
   maxTurn,
   timelines,
+  branchInfo = [],
   selectedCell,
   onCellClick,
   onPieceClick,
@@ -90,6 +118,13 @@ export function BoardGrid({
     panStart.current = null;
   }
 
+  // Pre-compute row index map for SVG line drawing
+  const rowOf = new Map(timelines.map((tl, i) => [tl, i]));
+
+  // SVG dimensions (approximate — cells may be wider than 7rem on large screens)
+  const svgW = PAD + LABEL_W + GAP_X + maxTurn * COL_STRIDE + PAD;
+  const svgH = PAD + HEADER_H + GAP_Y + timelines.length * ROW_STRIDE + PAD;
+
   return (
     <div
       ref={scrollRef}
@@ -100,8 +135,52 @@ export function BoardGrid({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
     >
+      {/* Wrapper gives the SVG overlay a relative anchor */}
+      <div className="relative" style={{ minWidth: svgW, minHeight: svgH }}>
+
+      {/* SVG branch-connector overlay — sits above grid, no pointer events */}
+      <svg
+        width={svgW}
+        height={svgH}
+        className="absolute inset-0 pointer-events-none"
+        style={{ zIndex: 5 }}
+      >
+        <defs>
+          <marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L6,3 z" fill="#6b7280" />
+          </marker>
+        </defs>
+        {branchInfo
+          .filter((b) => b.parentTimelineId !== null && b.divergedAtTurn !== null)
+          .map((b) => {
+            const parentRow = rowOf.get(b.parentTimelineId!);
+            const childRow = rowOf.get(b.timelineId);
+            if (parentRow === undefined || childRow === undefined) return null;
+            const col = (b.divergedAtTurn! - 1); // 0-based column index
+            const src = cellCenter(parentRow, col);
+            const dst = cellCenter(childRow, col);
+            // Line from bottom of parent cell to top of child cell
+            const x = src.x;
+            const y1 = src.y + CELL_H / 2 + 2;
+            const y2 = dst.y - CELL_H / 2 - 2;
+            return (
+              <g key={b.timelineId}>
+                <line
+                  x1={x} y1={y1} x2={x} y2={y2}
+                  stroke="#6b7280"
+                  strokeWidth={1.5}
+                  strokeDasharray="4 3"
+                  markerEnd="url(#arrow)"
+                />
+                {/* Dot at origin */}
+                <circle cx={x} cy={y1} r={3} fill="#6b7280" />
+              </g>
+            );
+          })}
+      </svg>
+
       <div
-        className="grid gap-1 p-2"
+        className="grid gap-x-1 gap-y-3 p-2"
         style={{
           gridTemplateColumns: `4rem repeat(${maxTurn}, minmax(7rem, 1fr))`,
           gridTemplateRows: `1.5rem repeat(${timelines.length}, 7rem)`,
@@ -128,7 +207,7 @@ export function BoardGrid({
             {/* Timeline label (sticky left) */}
             <div
               className="sticky left-0 z-10 flex items-center justify-end pr-2 text-xs text-gray-500 font-mono bg-gray-950 cursor-pointer hover:text-gray-300"
-              onClick={() => scrollRef.current?.scrollTo({ top: rowIndex * ROW_HEIGHT, behavior: 'smooth' })}
+              onClick={() => scrollRef.current?.scrollTo({ top: rowIndex * ROW_STRIDE, behavior: 'smooth' })}
             >
               {timelineId}
             </div>
@@ -156,6 +235,7 @@ export function BoardGrid({
           </React.Fragment>
         ))}
       </div>
+      </div> {/* end relative wrapper */}
     </div>
   );
 }

--- a/apps/client/src/components/GameView.tsx
+++ b/apps/client/src/components/GameView.tsx
@@ -99,7 +99,31 @@ export function GameView({ gameId, playerId, onPlayerSwitch, onLeave }: GameView
     return atCurrentTurn.includes('TL0') ? 'TL0' : (atCurrentTurn[0] ?? 'TL0');
   })();
 
-  const timelines = [...new Set(data.boards.map((b) => b.address.timeline as string))].sort();
+  // DFS order: newest child immediately below its parent, older siblings pushed further down.
+  // Guarantees connecting lines from parent to newest child never cross sibling branch lines.
+  const timelines = (() => {
+    const info = data.branchInfo ?? [];
+    const childrenOf = new Map<string, string[]>();
+    let root: string | undefined;
+    for (const b of info) {
+      if (!b.parentTimelineId) { root = b.timelineId; }
+      else {
+        const list = childrenOf.get(b.parentTimelineId) ?? [];
+        list.push(b.timelineId);
+        childrenOf.set(b.parentTimelineId, list);
+      }
+    }
+    if (!root) return [...new Set(data.boards.map((b) => b.address.timeline as string))].sort();
+    const result: string[] = [];
+    function dfs(id: string) {
+      result.push(id);
+      const children = childrenOf.get(id) ?? [];
+      // Newest child first (server appends in creation order, so reverse = newest first)
+      for (let i = children.length - 1; i >= 0; i--) dfs(children[i]!);
+    }
+    dfs(root);
+    return result;
+  })();
   const maxTurn = Math.max(activeTurn, ...data.boards.map((b) => b.address.turn as number));
 
   // Read piece's current region fresh from server data to avoid stale closure
@@ -315,6 +339,7 @@ export function GameView({ gameId, playerId, onPlayerSwitch, onLeave }: GameView
               cells={cells}
               maxTurn={maxTurn}
               timelines={timelines}
+              branchInfo={data.branchInfo ?? []}
               selectedCell={selectedBoard}
               onCellClick={handleCellClick}
               onPieceClick={handlePieceClick}

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -187,6 +187,11 @@ export const appRouter = router({
           pluginData: board.pluginData,
           inStabilizationPeriod: state.branchTree.nodes[board.address.timeline as string]?.inStabilizationPeriod ?? false,
         })),
+        branchInfo: Object.values(state.branchTree.nodes).map((node) => ({
+          timelineId: node.timelineId as string,
+          parentTimelineId: node.parentTimelineId as string | null,
+          divergedAtTurn: node.divergedAtTurn as number | null,
+        })),
         currentPlayer: activePlayer,
         globalTurn: state.order.globalTurn,
         winner: state.winner,
@@ -222,6 +227,9 @@ export const appRouter = router({
 
       const address = input.boardAddress as { timeline: ReturnType<typeof Object.keys>[number]; turn: number } as Parameters<typeof processAction>[4];
 
+      // Counter for short timeline IDs: TL1, TL2, … (TL0 is the root, already named by plugin).
+      let nextTlCounter = Object.keys(state.branchTree.nodes).length;
+
       try {
         state = processAction(
           state,
@@ -231,6 +239,7 @@ export const appRouter = router({
           address,
           false,
           undefined,
+          () => `TL${nextTlCounter++}`,
         );
       } catch (err) {
         throw new TRPCError({

--- a/packages/engine/src/game-loop.ts
+++ b/packages/engine/src/game-loop.ts
@@ -69,6 +69,7 @@ export function processAction(
   address: BoardAddress,
   isHalfAction: boolean,
   halfActionBranchId: BranchId | undefined,
+  nextTimelineId?: () => string,
 ): GameLoopState {
   const player = getCurrentPlayer(state.order);
 
@@ -177,7 +178,7 @@ export function processAction(
       }
     } else {
       // New branch — pre-assign the timeline ID (= branchId)
-      const newTimelineId = `TL-branch-${action.id}` as TimelineId;
+      const newTimelineId = (nextTimelineId ? nextTimelineId() : `TL-branch-${action.id}`) as TimelineId;
       const branchId = newTimelineId as unknown as BranchId;
 
       // The first board of the new timeline is at originAddress.turn — the timestep


### PR DESCRIPTION
## Summary

Three visual improvements to the multiverse board grid:

### 1. Simplified timeline naming
Branch timeline IDs are now `TL1`, `TL2`, `TL3`, … instead of `TL-branch-action-<timestamp>-<random>`.
- Engine: `processAction` accepts optional `nextTimelineId?: () => string`
- Server: threads a counter `() => \`TL${n++}\`` through `submitAction`

### 2. Newest-child-first row ordering
Timelines are now sorted by DFS pre-order with newest child first. When a new branch is created off a parent, it appears **immediately below** the parent row — older siblings shift down. This prevents branch connecting lines from crossing each other.
- Server: `getVisibleState` exposes `branchInfo` (parentTimelineId, divergedAtTurn per timeline)
- Client: replaces `.sort()` with DFS traversal using branchInfo

### 3. SVG branch connecting lines + row spacing
An SVG overlay draws a dashed vertical line with dot-origin and arrowhead from each parent's origin board down to the child timeline's row. Row gap increased from `gap-1` to `gap-y-3` for visual breathing room.

Closes #26

## Dependencies
Requires PRs #27, #28, #29, #30 merged to dev first (all formation-window and stabilization fixes).

## Test plan
- [x] Engine: 60 tests pass, typecheck clean
- [x] Server: typecheck clean  
- [x] Client: typecheck clean
- [ ] Manual: new game → time travel → verify TL1 naming, row below parent, dashed line visible