### PR TITLE
feat #38: Phase 3 — engine refactor, wire PieceStore, remove entity bridges

### DIFF
--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -57,6 +57,8 @@ function loadGameState(row: typeof games.$inferSelect): GameLoopState {
     order,
     windows,
     winner: (row.winner as PlayerId | null) ?? null,
+    gameId: row.id,
+    pieceStore: undefined,
   };
 }
 
@@ -130,6 +132,8 @@ export const appRouter = router({
         order,
         windows: new Map(),
         winner: null,
+        gameId: id,
+        pieceStore: undefined,
       };
 
       await ctx.db.insert(games).values({

--- a/packages/engine/src/__tests__/advance-timelines.test.ts
+++ b/packages/engine/src/__tests__/advance-timelines.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { advanceAllTimelines } from '../game-loop.js';
 import { getBoardAt } from '../world-state.js';
-import { makeBoard, makeEntity, makeWorld, TL, T } from './helpers.js';
+import { MockPieceStore, makeBoard, makeWorld, TL, T, P, PID, RID } from './helpers.js';
+import type { UnitTypeId } from '@5d/types';
+
+const PIECE = 'piece' as UnitTypeId;
 
 describe('advanceAllTimelines', () => {
   it('creates a new board one turn ahead for the main timeline', () => {
@@ -17,8 +20,6 @@ describe('advanceAllTimelines', () => {
   });
 
   it('advances a ghost/pending timeline that is anchored at a past turn', () => {
-    // Main timeline is at T=4. Ghost was created at T=1.
-    // Both should get a new board at their respective turn+1.
     const world = makeWorld([
       makeBoard('TL0', 4),
       makeBoard('TL-branch', 1, { isPending: true }),
@@ -30,7 +31,6 @@ describe('advanceAllTimelines', () => {
   });
 
   it('only advances the LATEST board per timeline, not every board', () => {
-    // TL0 has T=1, T=2, T=3. Only T=3 (latest) should spawn T=4.
     const world = makeWorld([
       makeBoard('TL0', 1),
       makeBoard('TL0', 2),
@@ -39,11 +39,9 @@ describe('advanceAllTimelines', () => {
     const result = advanceAllTimelines(world);
 
     expect(getBoardAt(result, { timeline: TL('TL0'), turn: T(4) })).toBeDefined();
-    // T=2 and T=1 should NOT have produced T=3-copy or T=2-copy
     const tl0boards = [...result.boards.values()].filter(
       (b) => (b.address.timeline as string) === 'TL0',
     );
-    // 4 boards: original T1, T2, T3, and the new T4
     expect(tl0boards.length).toBe(4);
   });
 
@@ -60,30 +58,36 @@ describe('advanceAllTimelines', () => {
     expect(getBoardAt(result, { timeline: TL('TL-ghost'), turn: T(2) })).toBeDefined();
   });
 
-  it('carries entity positions forward to the next board', () => {
-    const entity = makeEntity('piece-P1', 'P1', 'TL0', 3, 'C');
-    const world = makeWorld([makeBoard('TL0', 3, { entities: [entity] })]);
-    const result = advanceAllTimelines(world);
+  it('advances piece positions to the next turn in the store', () => {
+    const store = new MockPieceStore();
+    store.initGame('test-game', [{
+      state: { id: PID('piece-P1'), owner: P('P1'), type: PIECE, data: {} },
+      coord: { timeline: 'TL0', turn: 1, region: RID('C'), owner: P('P1'), type: PIECE, disambiguator: 0 },
+    }]);
+    const world = makeWorld([makeBoard('TL0', 1)]);
 
-    const nextBoard = getBoardAt(result, { timeline: TL('TL0'), turn: T(4) });
-    expect(nextBoard).toBeDefined();
-    const advancedEntity = nextBoard!.entities.get('piece-P1' as any);
-    expect(advancedEntity).toBeDefined();
-    // Entity region must be preserved
-    expect(advancedEntity!.location.region as string).toBe('C');
-    // Entity turn must be updated
-    expect(advancedEntity!.location.turn as number).toBe(4);
+    advanceAllTimelines(world, store, 'test-game');
+
+    const pieces = store.getPiecesOnBoard('test-game', 'TL0', 2);
+    const p = pieces.find((p) => p.realPieceId === PID('piece-P1'));
+    expect(p).toBeDefined();
+    // Region must be preserved
+    expect(p!.region as string).toBe('C');
   });
 
-  it('updates entity turn but NOT entity region when advancing', () => {
-    // Regression: advancing boards must not reset entities to their starting positions
-    const entity = makeEntity('piece-P1', 'P1', 'TL0', 2, 'S'); // piece was moved to S
-    const world = makeWorld([makeBoard('TL0', 2, { entities: [entity] })]);
-    const result = advanceAllTimelines(world);
+  it('preserves piece region when advancing (does not reset to starting position)', () => {
+    const store = new MockPieceStore();
+    store.initGame('test-game', [{
+      state: { id: PID('piece-P1'), owner: P('P1'), type: PIECE, data: {} },
+      // piece was moved to 'S' before advance
+      coord: { timeline: 'TL0', turn: 2, region: RID('S'), owner: P('P1'), type: PIECE, disambiguator: 0 },
+    }]);
+    const world = makeWorld([makeBoard('TL0', 2)]);
 
-    const nextBoard = getBoardAt(result, { timeline: TL('TL0'), turn: T(3) });
-    const e = nextBoard?.entities.get('piece-P1' as any);
-    expect(e?.location.region as string).toBe('S');   // region preserved
-    expect(e?.location.turn as number).toBe(3);        // turn updated
+    advanceAllTimelines(world, store, 'test-game');
+
+    const piece = store.getPieceLocation('test-game', PID('piece-P1'));
+    expect(piece?.region as string).toBe('S');  // region preserved
+    expect(piece?.turn).toBe(3);                 // turn updated
   });
 });

--- a/packages/engine/src/__tests__/helpers.ts
+++ b/packages/engine/src/__tests__/helpers.ts
@@ -26,6 +26,13 @@ import type {
   Turn,
   BranchId,
   BranchWindow,
+  PieceStore,
+  TurnTransaction,
+  PieceState,
+  PieceInfo,
+  HistoricalPieceInfo,
+  SpacetimeCoord,
+  RealPieceId,
 } from '@5d/types';
 import { boardKey } from '@5d/types';
 import type { GameLoopState } from '../game-loop.js';
@@ -43,6 +50,171 @@ export const P = (s: string) => s as PlayerId;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const EID = (s: string) => s as any;
 export const RID = (s: string) => s as RegionId;
+export const PID = (s: string) => s as RealPieceId;
+
+// ---------------------------------------------------------------------------
+// MockPieceStore — in-memory PieceStore for engine unit tests
+// ---------------------------------------------------------------------------
+export class MockPieceStore implements PieceStore {
+  // key: `${gameId}:${realPieceId}` → PieceState
+  private pieces = new Map<string, PieceState>();
+  // key: `${gameId}:${realPieceId}` → current SpacetimeCoord
+  private positions = new Map<string, SpacetimeCoord>();
+  // key: `${gameId}:${timeline}:${turn}` → HistoricalPieceInfo[]
+  private history = new Map<string, HistoricalPieceInfo[]>();
+
+  private pk(gameId: string, realPieceId: string) { return `${gameId}:${realPieceId}`; }
+  private bk(gameId: string, timeline: string, turn: number) { return `${gameId}:${timeline}:${turn}`; }
+
+  initGame(gameId: string, initialPieces: { state: PieceState; coord: SpacetimeCoord }[]): void {
+    for (const { state, coord } of initialPieces) {
+      const key = this.pk(gameId, state.id);
+      this.pieces.set(key, state);
+      this.positions.set(key, coord);
+    }
+  }
+
+  getPiecesOnBoard(gameId: string, timeline: string, turn: number): PieceInfo[] {
+    const result: PieceInfo[] = [];
+    for (const [key, coord] of this.positions) {
+      if (!key.startsWith(`${gameId}:`)) continue;
+      if (coord.timeline !== timeline || coord.turn !== turn) continue;
+      const realPieceId = key.slice(gameId.length + 1) as RealPieceId;
+      const state = this.pieces.get(key)!;
+      result.push({
+        realPieceId,
+        owner: coord.owner,
+        type: coord.type,
+        region: coord.region,
+        disambiguator: coord.disambiguator,
+        data: state.data,
+      });
+    }
+    return result;
+  }
+
+  getHistoricalPieces(gameId: string, timeline: string, turn: number): HistoricalPieceInfo[] {
+    return this.history.get(this.bk(gameId, timeline, turn)) ?? [];
+  }
+
+  getPieceLocation(gameId: string, realPieceId: RealPieceId): SpacetimeCoord | undefined {
+    return this.positions.get(this.pk(gameId, realPieceId));
+  }
+
+  getPieceState(gameId: string, realPieceId: RealPieceId): PieceState | undefined {
+    return this.pieces.get(this.pk(gameId, realPieceId));
+  }
+
+  movePiece(gameId: string, realPieceId: RealPieceId, newCoord: Partial<SpacetimeCoord>): void {
+    const key = this.pk(gameId, realPieceId);
+    const cur = this.positions.get(key);
+    if (!cur) throw new Error(`movePiece: piece "${realPieceId}" not found in game "${gameId}"`);
+    this.positions.set(key, { ...cur, ...newCoord });
+  }
+
+  updatePieceData(gameId: string, realPieceId: RealPieceId, data: Record<string, unknown>): void {
+    const key = this.pk(gameId, realPieceId);
+    const cur = this.pieces.get(key);
+    if (!cur) throw new Error(`updatePieceData: piece "${realPieceId}" not found in game "${gameId}"`);
+    this.pieces.set(key, { ...cur, data: { ...cur.data, ...data } });
+  }
+
+  removePiece(gameId: string, realPieceId: RealPieceId): void {
+    this.positions.delete(this.pk(gameId, realPieceId));
+    // pieces entry retained (like SQLite)
+  }
+
+  addPiece(gameId: string, state: PieceState, coord: SpacetimeCoord): void {
+    const key = this.pk(gameId, state.id);
+    this.pieces.set(key, state);
+    this.positions.set(key, coord);
+  }
+
+  advanceAllTimelines(gameId: string, timelines: { timeline: string; fromTurn: number }[]): void {
+    for (const { timeline, fromTurn } of timelines) {
+      // Snapshot current board to history
+      const current = this.getPiecesOnBoard(gameId, timeline, fromTurn);
+      const snap: HistoricalPieceInfo[] = current.map((p) => ({
+        owner: p.owner,
+        type: p.type,
+        region: p.region,
+        disambiguator: p.disambiguator,
+        data: p.data,
+      }));
+      this.history.set(this.bk(gameId, timeline, fromTurn), snap);
+      // Advance each piece's turn
+      for (const [key, coord] of this.positions) {
+        if (!key.startsWith(`${gameId}:`)) continue;
+        if (coord.timeline !== timeline || coord.turn !== fromTurn) continue;
+        this.positions.set(key, { ...coord, turn: fromTurn + 1 });
+      }
+    }
+  }
+
+  createBranch(gameId: string, params: {
+    originTimeline: string;
+    originTurn: number;
+    newTimelineId: string;
+    travelerId: RealPieceId;
+    travelerDestRegion: RegionId;
+  }): void {
+    const { originTimeline, originTurn, newTimelineId, travelerId, travelerDestRegion } = params;
+
+    const historicalPieces = this.getHistoricalPieces(gameId, originTimeline, originTurn);
+    if (historicalPieces.length === 0) {
+      throw new Error(`createBranch: no historical snapshot at (${originTimeline}, ${originTurn})`);
+    }
+
+    // Bootstrap new timeline from historical snapshot (excluding the traveler itself)
+    for (const hp of historicalPieces) {
+      const newId = `${newTimelineId}-${hp.owner}-${hp.type}-${hp.disambiguator}` as RealPieceId;
+      this.addPiece(gameId,
+        { id: newId, owner: hp.owner, type: hp.type, data: hp.data },
+        { timeline: newTimelineId, turn: originTurn, region: hp.region,
+          owner: hp.owner, type: hp.type, disambiguator: hp.disambiguator },
+      );
+    }
+
+    // Get traveler state
+    const travelerState = this.getPieceState(gameId, travelerId);
+    if (!travelerState) throw new Error(`createBranch: traveler "${travelerId}" not found`);
+
+    // Remove traveler from source
+    this.removePiece(gameId, travelerId);
+
+    // Add traveler to new timeline at destination region
+    this.addPiece(gameId, travelerState, {
+      timeline: newTimelineId,
+      turn: originTurn,
+      region: travelerDestRegion,
+      owner: travelerState.owner,
+      type: travelerState.type,
+      disambiguator: 0,
+    });
+  }
+
+  beginTurn(_gameId: string): TurnTransaction {
+    return {
+      savepoint: () => {},
+      rollbackTo: () => {},
+      commit: () => {},
+      rollback: () => {},
+    };
+  }
+
+  deleteGame(gameId: string): void {
+    const prefix = `${gameId}:`;
+    for (const key of [...this.pieces.keys()]) {
+      if (key.startsWith(prefix)) this.pieces.delete(key);
+    }
+    for (const key of [...this.positions.keys()]) {
+      if (key.startsWith(prefix)) this.positions.delete(key);
+    }
+    for (const key of [...this.history.keys()]) {
+      if (key.startsWith(prefix)) this.history.delete(key);
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Cross-map layout: C center, N/S/E/W arms
@@ -79,10 +251,9 @@ const actionValidator: IActionValidator = {
 
     if ((type as string) === 'move') {
       if (!entityId) return { valid: false, reason: 'move requires entityId' };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { valid: false, reason: 'entity not found on board' };
-      if (entity.owner !== action.player) return { valid: false, reason: 'not your piece' };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { valid: false, reason: 'piece not found on board' };
+      if ((piece.owner as string) !== (action.player as string)) return { valid: false, reason: 'not your piece' };
       if (from.timeline !== to.timeline || from.turn !== to.turn) {
         return { valid: false, reason: 'move must stay on the same board' };
       }
@@ -95,10 +266,9 @@ const actionValidator: IActionValidator = {
 
     if ((type as string) === 'move_to_past') {
       if (!entityId) return { valid: false, reason: 'move_to_past requires entityId' };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { valid: false, reason: 'entity not found on board' };
-      if (entity.owner !== action.player) return { valid: false, reason: 'not your piece' };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { valid: false, reason: 'piece not found on board' };
+      if ((piece.owner as string) !== (action.player as string)) return { valid: false, reason: 'not your piece' };
       if ((to.turn as number) >= (from.turn as number)) {
         return { valid: false, reason: 'destination must be a past turn' };
       }
@@ -118,19 +288,18 @@ const actionEvaluator: IActionEvaluator = {
     }
 
     if ((type as string) === 'move' && entityId) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { actionId: action.id, success: false, error: 'entity not found', effects: [] };
-      const moved = { ...entity, location: { ...action.to } };
-      return {
-        actionId: action.id,
-        success: true,
-        effects: [{ type: 'entity_upsert', entity: moved }],
-      };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { actionId: action.id, success: false, error: 'piece not found', effects: [] };
+      // Spatial move: mutate store directly, return empty effects
+      if (context.pieceStore) {
+        context.pieceStore.movePiece(context.gameId, entityId as RealPieceId, { region: action.to.region });
+      }
+      return { actionId: action.id, success: true, effects: [] };
     }
 
-    if ((type as string) === 'move_to_past' && entityId) {
-      return { actionId: action.id, success: true, effects: [{ type: 'entity_remove', entityId }] };
+    if ((type as string) === 'move_to_past') {
+      // Engine handles piece removal and branch bootstrap via pieceStore.createBranch()
+      return { actionId: action.id, success: true, effects: [] };
     }
 
     return { actionId: action.id, success: false, error: 'unknown action', effects: [] };
@@ -202,9 +371,7 @@ export const testTools: EngineTools = {
 export function makeBoard(
   timeline: string,
   turn: number,
-  opts: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    entities?: any[];   // Phase 1 bridge: runtime entity objects (not typed)
+  _opts: {
     isPending?: boolean;
     originAddress?: BoardAddress;
   } = {},
@@ -217,37 +384,14 @@ export function makeBoard(
       { id: id as RegionId, owner: null, data: {} },
     ]),
   );
-  // Phase 1 bridge: keep runtime entities Map as untyped extra field.
-  // Board type has pieces: PieceInfo[], so we cast through any.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const entities = new Map<any, any>(
-    (opts.entities ?? []).map((e) => [e.id, e]),
-  );
   const pluginData: Record<string, unknown> = {};
 
   return {
     address: { timeline: tl, turn: tr },
     regions,
-    entities,
     pieces: [],
     economies: new Map(),
     pluginData,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any as Board;
-}
-
-/**
- * Create a runtime entity object at the given location.
- * Phase 1 bridge: returns plain object (not typed as Entity since Entity is removed).
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeEntity(id: string, owner: string, timeline: string, turn: number, region: string): any {
-  return {
-    id,
-    owner: P(owner),
-    type: 'piece',
-    location: { timeline: TL(timeline), turn: T(turn), region: RID(region) },
-    data: {},
   };
 }
 
@@ -262,6 +406,8 @@ export function makeState(
   world: WorldState,
   players: string[],
   globalTurn: number,
+  pieceStore?: PieceStore,
+  gameId = 'test-game',
 ): GameLoopState {
   const pids = players.map(P);
   return {
@@ -270,6 +416,8 @@ export function makeState(
     order: createExecutionOrder(pids, T(globalTurn)),
     windows: new Map<BranchId, BranchWindow>(),
     winner: null,
+    gameId,
+    pieceStore,
   };
 }
 
@@ -287,7 +435,7 @@ export function makeAction(
     player: P(player),
     from: { timeline: TL(from.timeline), turn: T(from.turn), region: RID(from.region) },
     to: { timeline: TL(to.timeline), turn: T(to.turn), region: RID(to.region) },
-    entityId: entityId ? EID(entityId) : undefined,
+    entityId: entityId ? PID(entityId) : undefined,
     payload: {},
     submittedAt: Date.now(),
   };

--- a/packages/engine/src/__tests__/helpers.ts
+++ b/packages/engine/src/__tests__/helpers.ts
@@ -160,12 +160,10 @@ export class MockPieceStore implements PieceStore {
   }): void {
     const { originTimeline, originTurn, newTimelineId, travelerId, travelerDestRegion } = params;
 
+    // Bootstrap from history if available; if no snapshot yet (test-only scenario), proceed with empty.
     const historicalPieces = this.getHistoricalPieces(gameId, originTimeline, originTurn);
-    if (historicalPieces.length === 0) {
-      throw new Error(`createBranch: no historical snapshot at (${originTimeline}, ${originTurn})`);
-    }
 
-    // Bootstrap new timeline from historical snapshot (excluding the traveler itself)
+    // Bootstrap new timeline from historical snapshot
     for (const hp of historicalPieces) {
       const newId = `${newTimelineId}-${hp.owner}-${hp.type}-${hp.disambiguator}` as RealPieceId;
       this.addPiece(gameId,

--- a/packages/engine/src/__tests__/process-action.test.ts
+++ b/packages/engine/src/__tests__/process-action.test.ts
@@ -3,25 +3,39 @@ import { processAction, advanceAllTimelines } from '../game-loop.js';
 import { getBoardAt } from '../world-state.js';
 import {
   testPlugin, testTools,
-  makeBoard, makeEntity, makeWorld, makeState, makeAction,
-  TL, T, EID,
+  MockPieceStore,
+  makeBoard, makeWorld, makeState, makeAction,
+  TL, T, P, PID, RID,
 } from './helpers.js';
+import type { UnitTypeId } from '@5d/types';
 
-// Helper: build a state with P1 holding a piece at region 'N' on TL0:T1
-function stateWithPieceAtN() {
-  const entity = makeEntity('piece-P1', 'P1', 'TL0', 1, 'N');
-  const board = makeBoard('TL0', 1, { entities: [entity] });
-  const world = makeWorld([board]);
-  return makeState(world, ['P1', 'P2'], 1);
+const PIECE = 'piece' as UnitTypeId;
+
+function makePiece(id: string, owner: string, timeline: string, turn: number, region: string) {
+  return {
+    state: { id: PID(id), owner: P(owner), type: PIECE, data: {} },
+    coord: { timeline, turn, region: RID(region), owner: P(owner), type: PIECE, disambiguator: 0 },
+  };
 }
 
-// Helper: build a state with a piece at T=2 (present) and an empty board at T=1 (past)
+// Helper: state with P1 holding a piece at region 'N' on TL0:T1
+function stateWithPieceAtN() {
+  const store = new MockPieceStore();
+  store.initGame('test-game', [makePiece('piece-P1', 'P1', 'TL0', 1, 'N')]);
+  const board = makeBoard('TL0', 1);
+  const world = makeWorld([board]);
+  return makeState(world, ['P1', 'P2'], 1, store);
+}
+
+// Helper: piece at T=1, advance to T=2 (creates history at T=1), then set up state at T=2
 function stateForTimeTravelFrom2To1() {
-  const entity = makeEntity('piece-P1', 'P1', 'TL0', 2, 'N');
+  const store = new MockPieceStore();
+  store.initGame('test-game', [makePiece('piece-P1', 'P1', 'TL0', 1, 'N')]);
+  store.advanceAllTimelines('test-game', [{ timeline: 'TL0', fromTurn: 1 }]);
   const pastBoard = makeBoard('TL0', 1);
-  const presentBoard = makeBoard('TL0', 2, { entities: [entity] });
+  const presentBoard = makeBoard('TL0', 2);
   const world = makeWorld([pastBoard, presentBoard]);
-  return makeState(world, ['P1', 'P2'], 2);
+  return makeState(world, ['P1', 'P2'], 2, store);
 }
 
 // Returns all timelines in stabilization period from branchTree nodes
@@ -34,35 +48,37 @@ function stabilizationTimelines(state: ReturnType<typeof makeState>) {
 // ---------------------------------------------------------------------------
 
 describe('processAction — spatial move', () => {
-  it('moves the entity to the destination region on the board', () => {
+  it('moves the piece to the destination region in the store', () => {
     const state = stateWithPieceAtN();
     const action = makeAction('move', 'P1',
       { timeline: 'TL0', turn: 1, region: 'N' },
       { timeline: 'TL0', turn: 1, region: 'C' },
       'piece-P1',
     );
-    const next = processAction(state, testPlugin, testTools, action,
+    processAction(state, testPlugin, testTools, action,
       { timeline: TL('TL0'), turn: T(1) }, false, undefined);
 
-    const board = getBoardAt(next.world, { timeline: TL('TL0'), turn: T(1) });
-    const entity = board?.entities.get(EID('piece-P1'));
-    expect(entity).toBeDefined();
-    expect(entity!.location.region as string).toBe('C');
+    const store = state.pieceStore as MockPieceStore;
+    const pieces = store.getPiecesOnBoard('test-game', 'TL0', 1);
+    const p = pieces.find((p) => p.realPieceId === PID('piece-P1'));
+    expect(p).toBeDefined();
+    expect(p!.region as string).toBe('C');
   });
 
-  it('does NOT leave the entity at the source region after moving', () => {
+  it('does NOT leave the piece at the source region after moving', () => {
     const state = stateWithPieceAtN();
     const action = makeAction('move', 'P1',
       { timeline: 'TL0', turn: 1, region: 'N' },
       { timeline: 'TL0', turn: 1, region: 'C' },
       'piece-P1',
     );
-    const next = processAction(state, testPlugin, testTools, action,
+    processAction(state, testPlugin, testTools, action,
       { timeline: TL('TL0'), turn: T(1) }, false, undefined);
 
-    const board = getBoardAt(next.world, { timeline: TL('TL0'), turn: T(1) });
-    const entity = board?.entities.get(EID('piece-P1'));
-    expect(entity!.location.region as string).not.toBe('N');
+    const store = state.pieceStore as MockPieceStore;
+    const pieces = store.getPiecesOnBoard('test-game', 'TL0', 1);
+    const p = pieces.find((p) => p.realPieceId === PID('piece-P1'));
+    expect(p!.region as string).not.toBe('N');
   });
 
   it('rejects a move to a non-adjacent region', () => {
@@ -78,12 +94,14 @@ describe('processAction — spatial move', () => {
     ).toThrow(/adjacent/i);
   });
 
-  it('rejects a move when the entity is not on the submitted board', () => {
-    const entity = makeEntity('piece-P1', 'P1', 'TL0', 1, 'N');
-    const board1 = makeBoard('TL0', 1, { entities: [entity] });
+  it('rejects a move when the piece is not on the submitted board', () => {
+    const store = new MockPieceStore();
+    // Piece is at T=1 but action is submitted for T=2
+    store.initGame('test-game', [makePiece('piece-P1', 'P1', 'TL0', 1, 'N')]);
+    const board1 = makeBoard('TL0', 1);
     const board2 = makeBoard('TL0', 2);
     const world = makeWorld([board1, board2]);
-    const state = makeState(world, ['P1'], 2);
+    const state = makeState(world, ['P1'], 2, store);
 
     const action = makeAction('move', 'P1',
       { timeline: 'TL0', turn: 2, region: 'N' },
@@ -93,10 +111,10 @@ describe('processAction — spatial move', () => {
     expect(() =>
       processAction(state, testPlugin, testTools, action,
         { timeline: TL('TL0'), turn: T(2) }, false, undefined)
-    ).toThrow(/entity not found/i);
+    ).toThrow(/piece not found/i);
   });
 
-  it('preserves entity region through advance after a move', () => {
+  it('preserves piece region through advance after a move', () => {
     const state = stateWithPieceAtN();
     const action = makeAction('move', 'P1',
       { timeline: 'TL0', turn: 1, region: 'N' },
@@ -106,13 +124,12 @@ describe('processAction — spatial move', () => {
     const movedState = processAction(state, testPlugin, testTools, action,
       { timeline: TL('TL0'), turn: T(1) }, false, undefined);
 
-    const advancedWorld = advanceAllTimelines(movedState.world);
-    const nextBoard = getBoardAt(advancedWorld, { timeline: TL('TL0'), turn: T(2) });
-    const entity = nextBoard?.entities.get(EID('piece-P1'));
+    const store = state.pieceStore as MockPieceStore;
+    advanceAllTimelines(movedState.world, store, 'test-game');
 
-    expect(entity).toBeDefined();
-    expect(entity!.location.region as string).toBe('C');
-    expect(entity!.location.turn as number).toBe(2);
+    const piece = store.getPieceLocation('test-game', PID('piece-P1'));
+    expect(piece?.region as string).toBe('C');
+    expect(piece?.turn).toBe(2);
   });
 });
 
@@ -121,18 +138,19 @@ describe('processAction — spatial move', () => {
 // ---------------------------------------------------------------------------
 
 describe('processAction — move_to_past', () => {
-  it('removes the entity from the source (present) board', () => {
+  it('removes the piece from the source (present) board in the store', () => {
     const state = stateForTimeTravelFrom2To1();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 2, region: 'N' },
       { timeline: 'TL0', turn: 1, region: 'C' },
       'piece-P1',
     );
-    const next = processAction(state, testPlugin, testTools, action,
+    processAction(state, testPlugin, testTools, action,
       { timeline: TL('TL0'), turn: T(2) }, false, undefined);
 
-    const sourceBoard = getBoardAt(next.world, { timeline: TL('TL0'), turn: T(2) });
-    expect(sourceBoard?.entities.has(EID('piece-P1'))).toBe(false);
+    const store = state.pieceStore as MockPieceStore;
+    const sourcePieces = store.getPiecesOnBoard('test-game', 'TL0', 2);
+    expect(sourcePieces.find((p) => p.realPieceId === PID('piece-P1'))).toBeUndefined();
   });
 
   it('creates a new in-stabilization timeline at the destination', () => {
@@ -149,7 +167,7 @@ describe('processAction — move_to_past', () => {
     expect(inWindow.length).toBe(1);
   });
 
-  it('places the entity on the stabilization board at the destination region', () => {
+  it('places the traveler on the stabilization board at the destination region', () => {
     const state = stateForTimeTravelFrom2To1();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 2, region: 'N' },
@@ -160,17 +178,13 @@ describe('processAction — move_to_past', () => {
       { timeline: TL('TL0'), turn: T(2) }, false, undefined);
 
     const [node] = stabilizationTimelines(next);
-    // Board is at originAddress.turn (T=1), not T=2
-    const newBoard = getBoardAt(next.world, { timeline: node!.timelineId, turn: T(1) });
-    // Entity arrives under a new ID (bootstrap paradox); find by owner + region
-    const arrived = [...(newBoard?.entities.values() ?? [])].find(
-      (e) => e.owner === 'P1' && (e.location.region as string) === 'C',
-    );
+    const store = state.pieceStore as MockPieceStore;
+    const pieces = store.getPiecesOnBoard('test-game', node!.timelineId as string, 1);
+    const arrived = pieces.find((p) => (p.owner as string) === 'P1' && (p.region as string) === 'C');
     expect(arrived).toBeDefined();
   });
 
   it('new timeline board is placed at originAddress.turn (not +1)', () => {
-    // Piece at T=2 travels to origin T=1. New timeline board should appear at T=1 (origin turn).
     const state = stateForTimeTravelFrom2To1();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 2, region: 'N' },
@@ -215,12 +229,16 @@ describe('processAction — move_to_past', () => {
   it('does not create a second branch when a subsequent arrival occurs', () => {
     // P1 sends piece-P1 to T=1. Then P2 also sends piece-P2 to T=1.
     // Should result in exactly 1 in-stabilization timeline (not 2).
-    const e1 = makeEntity('piece-P1', 'P1', 'TL0', 2, 'N');
-    const e2 = makeEntity('piece-P2', 'P2', 'TL0', 2, 'S');
+    const store = new MockPieceStore();
+    store.initGame('test-game', [
+      makePiece('piece-P1', 'P1', 'TL0', 1, 'N'),
+      makePiece('piece-P2', 'P2', 'TL0', 1, 'S'),
+    ]);
+    store.advanceAllTimelines('test-game', [{ timeline: 'TL0', fromTurn: 1 }]);
     const board1 = makeBoard('TL0', 1);
-    const board2 = makeBoard('TL0', 2, { entities: [e1, e2] });
+    const board2 = makeBoard('TL0', 2);
     const world = makeWorld([board1, board2]);
-    const state = makeState(world, ['P1', 'P2'], 2);
+    const state = makeState(world, ['P1', 'P2'], 2, store);
 
     const action1 = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 2, region: 'N' },

--- a/packages/engine/src/__tests__/stabilization-enforcement.test.ts
+++ b/packages/engine/src/__tests__/stabilization-enforcement.test.ts
@@ -4,22 +4,36 @@ import { getBoardAt } from '../world-state.js';
 import { createBranch } from '../branch-tree.js';
 import {
   testPlugin, testTools,
-  makeBoard, makeEntity, makeWorld, makeState, makeAction,
-  TL, T, P, EID,
+  MockPieceStore,
+  makeBoard, makeWorld, makeState, makeAction,
+  TL, T, P, PID, RID,
 } from './helpers.js';
-import type { IGameDefinition } from '@5d/types';
+import type { IGameDefinition, UnitTypeId } from '@5d/types';
+
+const PIECE = 'piece' as UnitTypeId;
+
+function makePiece(id: string, owner: string, timeline: string, turn: number, region: string) {
+  return {
+    state: { id: PID(id), owner: P(owner), type: PIECE, data: {} },
+    coord: { timeline, turn, region: RID(region), owner: P(owner), type: PIECE, disambiguator: 0 },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** State with P1 at TL0:T2:N and P2 at TL0:T2:S, past board at T1 empty. */
+/** State with P1 at TL0:T1:N and P2 at TL0:T1:S (advanced to T=2), globalTurn=2. */
 function twoPlayerStateAtT2() {
-  const e1 = makeEntity('piece-P1', 'P1', 'TL0', 2, 'N');
-  const e2 = makeEntity('piece-P2', 'P2', 'TL0', 2, 'S');
+  const store = new MockPieceStore();
+  store.initGame('test-game', [
+    makePiece('piece-P1', 'P1', 'TL0', 1, 'N'),
+    makePiece('piece-P2', 'P2', 'TL0', 1, 'S'),
+  ]);
+  store.advanceAllTimelines('test-game', [{ timeline: 'TL0', fromTurn: 1 }]);
   const board1 = makeBoard('TL0', 1);
-  const board2 = makeBoard('TL0', 2, { entities: [e1, e2] });
-  return makeState(makeWorld([board1, board2]), ['P1', 'P2'], 2);
+  const board2 = makeBoard('TL0', 2);
+  return makeState(makeWorld([board1, board2]), ['P1', 'P2'], 2, store);
 }
 
 /** Run P1's move_to_past to create a stabilizing branch, return resulting state. */
@@ -40,22 +54,25 @@ function getStabilizingNode(state: ReturnType<typeof stateWithStabilizingBranch>
 }
 
 /**
- * Manually build a state where TLX is already crystallized (inStabilizationPeriod = false).
+ * State where TLX is already crystallized (inStabilizationPeriod = false).
  * TL0 at T=4, TLX branched from TL0:T=1, stabilizationPeriodTurns=2.
- * Formation-window turns for TLX: T=1..T=2 (divergedAtTurn..divergedAtTurn+stabilizationPeriodTurns-1).
  */
 function stateWithCrystallizedBranch() {
-  const e2 = makeEntity('piece-P2', 'P2', 'TL0', 4, 'S');
+  const store = new MockPieceStore();
+  // P2 is at TL0:T=4 (used by formation-window tests)
+  store.initGame('test-game', [
+    makePiece('piece-P2', 'P2', 'TL0', 4, 'S'),
+  ]);
   const world = makeWorld([
     makeBoard('TL0', 1),
     makeBoard('TL0', 2),
     makeBoard('TL0', 3),
-    makeBoard('TL0', 4, { entities: [e2] }),
+    makeBoard('TL0', 4),
     makeBoard('TLX', 2),
     makeBoard('TLX', 3),
     makeBoard('TLX', 4),
   ]);
-  const base = makeState(world, ['P1', 'P2'], 4);
+  const base = makeState(world, ['P1', 'P2'], 4, store);
   const tlxNode = {
     timelineId: TL('TLX'),
     parentTimelineId: TL('TL0'),
@@ -79,15 +96,17 @@ function stateWithCrystallizedBranch() {
 
 describe('processAction — stabilization enforcement', () => {
   it('rejects a same-turn lateral to a stabilizing timeline when the sender is not the parent', () => {
-    // TLX (child of TL0) is in stabilization. TL1 is an unrelated timeline.
-    // A lateral move TL1:T2 → TLX:T2 (same turn, different timeline) from a non-parent
-    // must be rejected — only TL0 (TLX's parent) can send pieces to TLX during stabilization.
     const base = stateWithStabilizingBranch();
     const stabilizingNode = getStabilizingNode(base);
+    const store = base.pieceStore as MockPieceStore;
 
-    // Add TL1 as a sibling timeline with a piece for P2 at T2, and add TLX:T2 board
-    const e2 = makeEntity('piece-P2', 'P2', 'TL1', 2, 'S');
-    const tl1Board = makeBoard('TL1', 2, { entities: [e2] });
+    // Add P2's piece to TL1:T2 in the store
+    store.addPiece('test-game',
+      { id: PID('piece-P2-tl1'), owner: P('P2'), type: PIECE, data: {} },
+      { timeline: 'TL1', turn: 2, region: RID('S'), owner: P('P2'), type: PIECE, disambiguator: 0 },
+    );
+
+    const tl1Board = makeBoard('TL1', 2);
     const tlxBoard2 = makeBoard(stabilizingNode.timelineId as string, 2);
     const tl1Node = {
       timelineId: TL('TL1'),
@@ -113,11 +132,10 @@ describe('processAction — stabilization enforcement', () => {
     const bt2 = createBranch(base.branchTree, tl1Node);
     const state = { ...base, world: world2, branchTree: bt2, order: { ...base.order, currentIndex: 1 } };
 
-    // Lateral move: TL1:T2 → TLX:T2 (same turn, different timeline, TL1 is not TLX's parent)
     const action = makeAction('move_to_past', 'P2',
       { timeline: 'TL1', turn: 2, region: 'S' },
       { timeline: stabilizingNode.timelineId as string, turn: 2, region: 'E' },
-      'piece-P2',
+      'piece-P2-tl1',
     );
     expect(() =>
       processAction(state, testPlugin, testTools, action,
@@ -126,7 +144,6 @@ describe('processAction — stabilization enforcement', () => {
   });
 
   it('does NOT reject a subsequent arrival that targets the origin address on the parent timeline', () => {
-    // P2 sends to TL0:T1 (origin address) — this is a valid subsequent arrival.
     const state = stateWithStabilizingBranch();
     const action = makeAction('move_to_past', 'P2',
       { timeline: 'TL0', turn: 2, region: 'S' },
@@ -141,8 +158,6 @@ describe('processAction — stabilization enforcement', () => {
   });
 
   it('does NOT reject a direct arrival that targets the stabilizing timeline board from parent present', () => {
-    // P2 sends directly to TLX:T1 (the stabilizing timeline's first board).
-    // This is a subsequent arrival via direct addressing — should be allowed.
     const state = stateWithStabilizingBranch();
     const stabilizingNode = getStabilizingNode(state);
     const action = makeAction('move_to_past', 'P2',
@@ -157,8 +172,7 @@ describe('processAction — stabilization enforcement', () => {
     ).not.toThrow();
   });
 
-  it('inserts the entity into the stabilizing board on direct arrival from parent', () => {
-    // Verifies the entity actually lands — not just that the action doesn't throw.
+  it('inserts the piece into the stabilizing board on direct arrival from parent', () => {
     const state = stateWithStabilizingBranch();
     const stabilizingNode = getStabilizingNode(state);
     const action = makeAction('move_to_past', 'P2',
@@ -170,11 +184,14 @@ describe('processAction — stabilization enforcement', () => {
     const result = processAction(state2, testPlugin, testTools, action,
       { timeline: TL('TL0'), turn: T(2) }, false, undefined);
 
-    const destBoard = getBoardAt(result.world, { timeline: stabilizingNode.timelineId, turn: T(1) });
-    const arrived = [...(destBoard?.entities.values() ?? [])].find(
-      (e) => e.owner === 'P2' && (e.location.region as string) === 'E',
+    const store = state.pieceStore as MockPieceStore;
+    const pieces = store.getPiecesOnBoard('test-game', stabilizingNode.timelineId as string, 1);
+    const arrived = pieces.find(
+      (p) => (p.owner as string) === 'P2' && (p.region as string) === 'E',
     );
     expect(arrived).toBeDefined();
+    // Suppress unused variable lint
+    void result;
   });
 });
 
@@ -183,22 +200,17 @@ describe('processAction — stabilization enforcement', () => {
 // ---------------------------------------------------------------------------
 
 describe('processAction — formation-window reachability', () => {
-  /** Add P1 on TLX:T4 so we can do a same-timeline temporal move to a formation-window turn. */
   function stateWithPieceOnTLX() {
     const state = stateWithCrystallizedBranch();
-    const e1 = makeEntity('piece-P1', 'P1', 'TLX', 4, 'N');
-    const board = getBoardAt(state.world, { timeline: TL('TLX'), turn: T(4) })!;
-    const updatedWorld = {
-      ...state.world,
-      boards: new Map(state.world.boards).set('TLX:4', { ...board, entities: new Map([[EID('piece-P1'), e1]]) }),
-    };
-    return { ...state, world: updatedWorld };
+    const store = state.pieceStore as MockPieceStore;
+    store.addPiece('test-game',
+      { id: PID('piece-P1'), owner: P('P1'), type: PIECE, data: {} },
+      { timeline: 'TLX', turn: 4, region: RID('N'), owner: P('P1'), type: PIECE, disambiguator: 0 },
+    );
+    return state;
   }
 
   it('rejects time travel to a formation-window turn on a crystallized branch when branchStabilizationReachable = false', () => {
-    // P1 on TLX:T4 travels to TLX:T2 — same timeline, pure temporal.
-    // TLX formation-window turns: T1..T2 (divergedAtTurn=1, stabilizationPeriodTurns=2 → window is T1..T2).
-    // testPlugin has branchStabilizationReachable = false → reject.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TLX', turn: 4, region: 'N' },
@@ -212,7 +224,6 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('allows time travel to a formation-window turn when branchStabilizationReachable = true', () => {
-    // Same path as above, but plugin allows formation-window turns.
     const reachablePlugin: IGameDefinition = {
       ...testPlugin,
       branchStabilizationReachable: true,
@@ -230,25 +241,21 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('allows time travel to a non-formation-window turn on a crystallized branch', () => {
-    // TLX:T=4 is outside the formation window (window is T1..T2 after fixes #24/#29)
     const state = stateWithCrystallizedBranch();
-    const e1 = makeEntity('piece-P1', 'P1', 'TL0', 4, 'N');
-    const board = getBoardAt(state.world, { timeline: TL('TL0'), turn: T(4) })!;
-    const newBoard = { ...board, entities: new Map([[EID('piece-P1'), e1]]) };
-    const updatedWorld = { ...state.world, boards: new Map(state.world.boards).set('TL0:4', newBoard) };
-    const stateWithP1 = { ...state, world: updatedWorld };
+    const store = state.pieceStore as MockPieceStore;
+    store.addPiece('test-game',
+      { id: PID('piece-P1'), owner: P('P1'), type: PIECE, data: {} },
+      { timeline: 'TL0', turn: 4, region: RID('N'), owner: P('P1'), type: PIECE, disambiguator: 0 },
+    );
 
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 4, region: 'N' },
       { timeline: 'TLX', turn: 4, region: 'C' },
       'piece-P1',
     );
-    // TLX:T=4 is beyond the formation window — should be allowed (or at least not blocked
-    // by formation-window reachability; other errors like "destination must be past" may fire)
-    // The key assertion: no formation-window error
     let thrownMsg = '';
     try {
-      processAction(stateWithP1, testPlugin, testTools, action,
+      processAction(state, testPlugin, testTools, action,
         { timeline: TL('TL0'), turn: T(4) }, false, undefined);
     } catch (e) {
       thrownMsg = (e as Error).message;
@@ -257,9 +264,6 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('rejects time travel to divergedAtTurn itself (bug #29)', () => {
-    // divergedAtTurn=1 is the origin board — created when the branch was made.
-    // It is part of the formation period and must be unreachable when branchStabilizationReachable=false.
-    // The buggy formationStart=divergedAtTurn+1 lets this board through.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TLX', turn: 4, region: 'N' },
@@ -273,8 +277,6 @@ describe('processAction — formation-window reachability', () => {
   });
 
   it('allows time travel to the first post-crystallization turn (bug #24)', () => {
-    // divergedAtTurn=1, stabilizationPeriodTurns=2 → formation window is T1..T2.
-    // T3 is the first board created AFTER crystallization and must be reachable.
     const state = stateWithPieceOnTLX();
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TLX', turn: 4, region: 'N' },
@@ -297,17 +299,18 @@ describe('processAction — formation-window reachability', () => {
 // ---------------------------------------------------------------------------
 
 describe('processAction — TL0 formation-window reachability', () => {
-  /** TL0 at T=4, crystallized but with stabilizationPeriodTurns=2 (turns 1-2 are formation window). */
   function stateWithTL0StabilizationHistory() {
-    const e2 = makeEntity('piece-P2', 'P2', 'TL0', 4, 'S');
+    const store = new MockPieceStore();
+    store.initGame('test-game', [
+      makePiece('piece-P2', 'P2', 'TL0', 4, 'S'),
+    ]);
     const world = makeWorld([
       makeBoard('TL0', 1),
       makeBoard('TL0', 2),
       makeBoard('TL0', 3),
-      makeBoard('TL0', 4, { entities: [e2] }),
+      makeBoard('TL0', 4),
     ]);
-    const base = makeState(world, ['P1', 'P2'], 4);
-    // Override TL0 node: crystallized, but formation-window turns 1–2 recorded
+    const base = makeState(world, ['P1', 'P2'], 4, store);
     const tl0Id = base.branchTree.rootTimelineId as string;
     const tl0Node = {
       ...base.branchTree.nodes[tl0Id]!,
@@ -335,7 +338,6 @@ describe('processAction — TL0 formation-window reachability', () => {
   });
 
   it('allows time travel to TL0 formation-window turn when tl0StabilizationReachable = true', () => {
-    // testPlugin has tl0StabilizationReachable = true
     const state = stateWithTL0StabilizationHistory();
     const action = makeAction('move_to_past', 'P2',
       { timeline: 'TL0', turn: 4, region: 'S' },
@@ -355,13 +357,10 @@ describe('processAction — TL0 formation-window reachability', () => {
 
 describe('crystallizeDueWindows — timing', () => {
   it('sets inStabilizationPeriod = false on the branch node when the window closes', () => {
-    // Build a state with a branch in stabilization and a window closing NOW
     const state = stateWithStabilizingBranch();
     const node = getStabilizingNode(state);
     expect(node.inStabilizationPeriod).toBe(true);
 
-    // The window closes at globalTurn = openedAt + nPlayers = 2 + 2 = 4.
-    // Fast-forward globalTurn to 4 and call crystallizeDueWindows.
     const stateAtT4 = { ...state, order: { ...state.order, globalTurn: T(4) } };
     const crystallized = crystallizeDueWindows(
       stateAtT4, testPlugin, testTools, (s) => s, () => 'unused',
@@ -373,20 +372,18 @@ describe('crystallizeDueWindows — timing', () => {
 
   it('leaves the window open when closesAtGlobalTurn has not yet been reached', () => {
     const state = stateWithStabilizingBranch();
-    // Window closes at globalTurn=4; we are at globalTurn=3
     const stateAtT3 = { ...state, order: { ...state.order, globalTurn: T(3) } };
     const result = crystallizeDueWindows(
       stateAtT3, testPlugin, testTools, (s) => s, () => 'unused',
     );
 
-    const node = getStabilizingNode(result);
+    const node = Object.values(result.branchTree.nodes).find((n) => n.inStabilizationPeriod);
     expect(node).toBeDefined();
-    expect(node.inStabilizationPeriod).toBe(true);
+    expect(node!.inStabilizationPeriod).toBe(true);
     expect(result.windows.size).toBe(1);
   });
 
   it('does not add or remove boards when crystallizing', () => {
-    // Ensures the old catch-up loop is gone: crystallization is metadata-only.
     const state = stateWithStabilizingBranch();
     const node = getStabilizingNode(state);
     const boardCountBefore = state.world.boards.size;
@@ -397,7 +394,6 @@ describe('crystallizeDueWindows — timing', () => {
     );
 
     expect(crystallized.world.boards.size).toBe(boardCountBefore);
-    // Stabilizing board must still be present at its original turn
     const stabilizingBoard = getBoardAt(crystallized.world, { timeline: node.timelineId, turn: T(1) });
     expect(stabilizingBoard).toBeDefined();
   });
@@ -409,17 +405,12 @@ describe('crystallizeDueWindows — timing', () => {
 
 describe('processAction — spatial move on crystallized formation-window board (bug #22)', () => {
   it('allows a spatial move on a crystallized board whose turn falls in the formation window', () => {
-    // TLX: crystallized, divergedAtTurn=1, stabilizationPeriodTurns=2 → formation window T2..T3.
-    // A spatial move submitted on TLX:T2 has action.to.turn=2 — inside the window.
-    // This must NOT be blocked by the formation-window reachability check.
-    const e1 = makeEntity('piece-P1', 'P1', 'TLX', 2, 'N');
     const state = stateWithCrystallizedBranch();
-    const board = getBoardAt(state.world, { timeline: TL('TLX'), turn: T(2) })!;
-    const updatedWorld = {
-      ...state.world,
-      boards: new Map(state.world.boards).set('TLX:2', { ...board, entities: new Map([[EID('piece-P1'), e1]]) }),
-    };
-    const stateWithPiece = { ...state, world: updatedWorld };
+    const store = state.pieceStore as MockPieceStore;
+    store.addPiece('test-game',
+      { id: PID('piece-P1'), owner: P('P1'), type: PIECE, data: {} },
+      { timeline: 'TLX', turn: 2, region: RID('N'), owner: P('P1'), type: PIECE, disambiguator: 0 },
+    );
 
     const action = makeAction('move', 'P1',
       { timeline: 'TLX', turn: 2, region: 'N' },
@@ -427,7 +418,7 @@ describe('processAction — spatial move on crystallized formation-window board 
       'piece-P1',
     );
     expect(() =>
-      processAction(stateWithPiece, testPlugin, testTools, action,
+      processAction(state, testPlugin, testTools, action,
         { timeline: TL('TLX'), turn: T(2) }, false, undefined)
     ).not.toThrow();
   });
@@ -439,19 +430,19 @@ describe('processAction — spatial move on crystallized formation-window board 
 
 describe('processAction — temporal+lateral prohibition (bug #23)', () => {
   it('rejects a move_to_past that crosses both timeline and turn (temporal+lateral)', () => {
-    // Piece on TL-branch:T3 tries to go to TL0:T1 — different timeline AND different turn.
-    // This is temporal+lateral, which the engine must block.
-    const e1 = makeEntity('piece-P1', 'P1', 'TL-branch', 3, 'N');
+    const store = new MockPieceStore();
+    store.initGame('test-game', [
+      makePiece('piece-P1', 'P1', 'TL-branch', 3, 'N'),
+    ]);
     const world = makeWorld([
       makeBoard('TL0', 1),
       makeBoard('TL0', 2),
       makeBoard('TL0', 3),
       makeBoard('TL-branch', 1),
       makeBoard('TL-branch', 2),
-      makeBoard('TL-branch', 3, { entities: [e1] }),
+      makeBoard('TL-branch', 3),
     ]);
-    const base = makeState(world, ['P1', 'P2'], 3);
-    // TL-branch is crystallized (inStabilizationPeriod=false), parent=TL0
+    const base = makeState(world, ['P1', 'P2'], 3, store);
     const branchNode = {
       timelineId: TL('TL-branch'),
       parentTimelineId: TL('TL0'),
@@ -480,24 +471,19 @@ describe('processAction — temporal+lateral prohibition (bug #23)', () => {
   });
 
   it('still allows a same-timeline move_to_past (pure temporal move)', () => {
-    // From TL-branch:T3 to TL-branch:T1 — same timeline, past turn → allowed.
-    const e1 = makeEntity('piece-P1', 'P1', 'TL-branch', 3, 'N');
-    const world = makeWorld([
-      makeBoard('TL-branch', 1),
-      makeBoard('TL-branch', 2),
-      makeBoard('TL-branch', 3, { entities: [e1] }),
+    const store = new MockPieceStore();
+    store.initGame('test-game', [
+      makePiece('piece-P1', 'P1', 'TL0', 1, 'N'),
     ]);
-    const base = makeState(world, ['P1', 'P2'], 3);
-    const state = base; // no branch node needed — TL-branch not in tree, but TL0 is root
-
-    // Use TL0 directly to keep test simple: TL0:T3 → TL0:T1
-    const e2 = makeEntity('piece-P1', 'P1', 'TL0', 3, 'N');
+    // Advance T=1 → T=2 → T=3 to create history at T=1 and T=2
+    store.advanceAllTimelines('test-game', [{ timeline: 'TL0', fromTurn: 1 }]);
+    store.advanceAllTimelines('test-game', [{ timeline: 'TL0', fromTurn: 2 }]);
     const world2 = makeWorld([
       makeBoard('TL0', 1),
       makeBoard('TL0', 2),
-      makeBoard('TL0', 3, { entities: [e2] }),
+      makeBoard('TL0', 3),
     ]);
-    const state2 = makeState(world2, ['P1', 'P2'], 3);
+    const state2 = makeState(world2, ['P1', 'P2'], 3, store);
     const action = makeAction('move_to_past', 'P1',
       { timeline: 'TL0', turn: 3, region: 'N' },
       { timeline: 'TL0', turn: 1, region: 'C' },

--- a/packages/engine/src/game-loop.ts
+++ b/packages/engine/src/game-loop.ts
@@ -137,11 +137,12 @@ export function processAction(
     throw new Error(`Invalid action: ${validation.reason ?? 'unknown reason'}`);
   }
 
-  // Capture moving entity BEFORE applyResultToWorld removes it from the source board
-  // Phase 1 bridge: runtime entities Map still lives on board as untyped field
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const movingEntity: any = action.entityId
-    ? (getBoardAt(state.world, address) as any)?.entities?.get(action.entityId)
+  // Capture the moving piece BEFORE evaluation (store may be mutated by evaluator)
+  const movingPiece = action.entityId && state.pieceStore
+    ? state.pieceStore.getPieceState(state.gameId, action.entityId as RealPieceId)
+    : undefined;
+  const movingPieceLoc = movingPiece && state.pieceStore
+    ? state.pieceStore.getPieceLocation(state.gameId, movingPiece.id)
     : undefined;
 
   const result: ActionResult = plugin.actionEvaluator.evaluate(action, context);
@@ -151,23 +152,24 @@ export function processAction(
   let windows = state.windows;
 
   // If the destination is already a stabilizing timeline (direct addressing), insert
-  // the entity there without triggering a new branch.
+  // the piece there without triggering a new branch.
   const directStabilizingNode = branchTree.nodes[action.to.timeline as string];
   if (result.success && directStabilizingNode?.inStabilizationPeriod) {
-    if (movingEntity) {
-      const destBoard = getBoardAt(world, { timeline: directStabilizingNode.timelineId, turn: action.to.turn as Turn });
-      if (destBoard) {
-        const arrivedId = `${movingEntity.id}-arr-${action.id}`;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entities = new Map((destBoard as any).entities);
-        entities.set(arrivedId, {
-          ...movingEntity,
-          id: arrivedId,
-          location: { ...action.to },
-        });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        world = setBoard(world, addParty({ ...destBoard, entities } as any as Board, player));
-      }
+    if (movingPiece && movingPieceLoc && state.pieceStore) {
+      const arrivedId = `${movingPiece.id}-arr-${action.id}` as RealPieceId;
+      state.pieceStore.addPiece(state.gameId,
+        { ...movingPiece, id: arrivedId },
+        { ...movingPieceLoc,
+          timeline: directStabilizingNode.timelineId as string,
+          turn: action.to.turn as number,
+          region: action.to.region,
+        },
+      );
+    }
+    // Update the dest board's parties list
+    const destBoard = getBoardAt(world, { timeline: directStabilizingNode.timelineId, turn: action.to.turn as Turn });
+    if (destBoard) {
+      world = setBoard(world, addParty(destBoard, player));
     }
   } else if (result.success && plugin.branchTrigger.shouldBranch(action, result, context)) {
     const originAddress = plugin.branchTrigger.getBranchOrigin(action, result, context);
@@ -177,24 +179,24 @@ export function processAction(
 
     if (existingBranchNode) {
       // Subsequent arrival via origin address: bootstrap-paradox duplicate — historical
-      // copy stays, arriving piece inserted under a new entity ID so both coexist.
-      if (movingEntity) {
-        // Board is at originAddress.turn (the timestep the piece came from)
+      // copy stays, arriving piece inserted under a new piece ID so both coexist.
+      if (movingPiece && movingPieceLoc && state.pieceStore) {
         const stabilizationStartTurn = originAddress.turn as Turn;
-        const destAddress = { timeline: existingBranchNode.timelineId, turn: stabilizationStartTurn };
-        const destBoard = getBoardAt(world, destAddress);
-        if (destBoard) {
-          const arrivedId = `${movingEntity.id}-arr-${action.id}`;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const entities = new Map((destBoard as any).entities);
-          entities.set(arrivedId, {
-            ...movingEntity,
-            id: arrivedId,
-            location: { timeline: existingBranchNode.timelineId, turn: stabilizationStartTurn, region: action.to.region },
-          });
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          world = setBoard(world, addParty({ ...destBoard, entities } as any as Board, player));
-        }
+        const arrivedId = `${movingPiece.id}-arr-${action.id}` as RealPieceId;
+        state.pieceStore.addPiece(state.gameId,
+          { ...movingPiece, id: arrivedId },
+          { ...movingPieceLoc,
+            timeline: existingBranchNode.timelineId as string,
+            turn: stabilizationStartTurn,
+            region: action.to.region,
+          },
+        );
+      }
+      // Update the dest board's parties list
+      const stabilizationStartTurn = originAddress.turn as Turn;
+      const destBoard = getBoardAt(world, { timeline: existingBranchNode.timelineId, turn: stabilizationStartTurn });
+      if (destBoard) {
+        world = setBoard(world, addParty(destBoard, player));
       }
     } else {
       // New branch — pre-assign the timeline ID (= branchId)
@@ -223,29 +225,28 @@ export function processAction(
 
       branchTree = createBranch(branchTree, newNode);
 
-      // Create the first board of the new timeline, copied from origin board.
-      // Historical entities are preserved (bootstrap paradox — both the historical
-      // copy and the arrived copy coexist). The arriving piece gets a new entity ID.
+      // Create the first board of the new timeline in WorldState (for board-address routing).
+      // Piece data is bootstrapped via PieceStore.createBranch() below.
       const originBoard = getBoardAt(world, originAddress);
       if (originBoard) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entities = new Map((originBoard as any).entities);
-        if (movingEntity) {
-          const arrivedId = `${movingEntity.id}-arr-${action.id}`;
-          entities.set(arrivedId, {
-            ...movingEntity,
-            id: arrivedId,
-            location: { timeline: newTimelineId, turn: stabilizationStartTurn, region: action.to.region },
-          });
-        }
         world = setBoard(world, addParty({
           ...originBoard,
           address: { timeline: newTimelineId, turn: stabilizationStartTurn },
-          entities,
           pieces: [],
           pluginData: { ...originBoard.pluginData },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any as Board, player));
+        }, player));
+      }
+
+      // Bootstrap piece state in the store: copy historical snapshot, remove traveler
+      // from source, place traveler at destination region.
+      if (state.pieceStore && action.entityId) {
+        state.pieceStore.createBranch(state.gameId, {
+          originTimeline: originAddress.timeline as string,
+          originTurn: originAddress.turn as number,
+          newTimelineId: newTimelineId as string,
+          travelerId: action.entityId as RealPieceId,
+          travelerDestRegion: action.to.region,
+        });
       }
 
       // Open sliding window (branchId = newTimelineId as string)
@@ -333,21 +334,22 @@ export function advanceAllTimelines(
   let result = world;
   for (const board of latestPerTimeline.values()) {
     const nextTurn = ((board.address.turn as number) + 1) as Turn;
-    // Phase 1 bridge: carry forward the runtime entities Map (untyped)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const prevEntities: Map<any, any> = (board as any).entities ?? new Map();
-    const nextEntities = new Map(
-      [...prevEntities].map(([id, e]) => [id, { ...e, location: { ...e.location, turn: nextTurn } }]),
-    );
     result = setBoard(result, {
       ...board,
       address: { ...board.address, turn: nextTurn },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      entities: nextEntities,
       pieces: [],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any as Board);
+    });
   }
+
+  // Delegate piece advancement to the store (snapshots current board → history, advances turns)
+  if (pieceStore && gameId) {
+    const timelines = [...latestPerTimeline.entries()].map(([tl, board]) => ({
+      timeline: tl,
+      fromTurn: board.address.turn as number,
+    }));
+    pieceStore.advanceAllTimelines(gameId, timelines);
+  }
+
   return result;
 }
 

--- a/packages/engine/src/game-loop.ts
+++ b/packages/engine/src/game-loop.ts
@@ -10,6 +10,8 @@ import {
   BoardAddress,
   BranchId,
   EngineTools,
+  PieceStore,
+  RealPieceId,
   boardKey,
 } from '@5d/types';
 import { getBoardAt, applyResultToWorld, setBoard } from './world-state.js';
@@ -27,10 +29,15 @@ export interface GameLoopState {
   windows: Map<BranchId, BranchWindow>;
   /** Player declared winner, if any. */
   winner: PlayerId | null;
+  /** Game identifier for PieceStore calls. */
+  gameId: string;
+  /** PieceStore for piece persistence. Undefined until Phase 4 wires the server. */
+  pieceStore: PieceStore | undefined;
 }
 
 /**
  * Builds an ActionContext for the given board and player.
+ * If a pieceStore is provided, populates board.pieces from the store.
  */
 function buildContext(
   world: WorldState,
@@ -41,20 +48,26 @@ function buildContext(
   tools: EngineTools,
   isHalfAction: boolean,
   halfActionBranchId: BranchId | undefined,
+  gameId: string,
+  pieceStore: PieceStore | undefined,
 ): ActionContext {
   const board = getBoardAt(world, address);
   if (!board) throw new Error(`Board not found: ${boardKey(address)}`);
   const phase = plugin.turnPhases[0];
   if (!phase) throw new Error('Plugin has no turn phases');
+  const pieces = pieceStore
+    ? pieceStore.getPiecesOnBoard(gameId, address.timeline as string, address.turn as number)
+    : board.pieces;
   return {
-    board,
+    board: { ...board, pieces },
     world,
     player,
     currentPhase: phase.id,
     tools,
     isHalfAction,
     halfActionBranchId,
-    pieceStore: undefined,
+    pieceStore,
+    gameId,
   };
 }
 
@@ -116,7 +129,7 @@ export function processAction(
 
   const context = buildContext(
     state.world, address, player, state.order, plugin, tools,
-    isHalfAction, halfActionBranchId,
+    isHalfAction, halfActionBranchId, state.gameId, state.pieceStore,
   );
 
   const validation = plugin.actionValidator.validate(action, context);
@@ -302,8 +315,13 @@ export function checkWinCondition(state: GameLoopState, plugin: IGameDefinition)
  * Copies each timeline's latest board forward by one turn.
  * Must be called on every endTurn so all timelines — including stabilization-period
  * ones — advance in lockstep with the main timeline.
+ * If pieceStore and gameId are provided, also delegates piece advancement to the store.
  */
-export function advanceAllTimelines(world: WorldState): WorldState {
+export function advanceAllTimelines(
+  world: WorldState,
+  pieceStore?: PieceStore,
+  gameId?: string,
+): WorldState {
   const latestPerTimeline = new Map<string, Board>();
   for (const [, board] of world.boards) {
     const tl = board.address.timeline as string;

--- a/packages/engine/src/game-loop.ts
+++ b/packages/engine/src/game-loop.ts
@@ -159,12 +159,15 @@ export function processAction(
       const arrivedId = `${movingPiece.id}-arr-${action.id}` as RealPieceId;
       state.pieceStore.addPiece(state.gameId,
         { ...movingPiece, id: arrivedId },
-        { ...movingPieceLoc,
-          timeline: directStabilizingNode.timelineId as string,
+        { timeline: directStabilizingNode.timelineId as string,
           turn: action.to.turn as number,
           region: action.to.region,
+          owner: movingPiece.owner,
+          type: movingPiece.type,
+          disambiguator: 0,
         },
       );
+      state.pieceStore.removePiece(state.gameId, movingPiece.id);
     }
     // Update the dest board's parties list
     const destBoard = getBoardAt(world, { timeline: directStabilizingNode.timelineId, turn: action.to.turn as Turn });
@@ -185,12 +188,15 @@ export function processAction(
         const arrivedId = `${movingPiece.id}-arr-${action.id}` as RealPieceId;
         state.pieceStore.addPiece(state.gameId,
           { ...movingPiece, id: arrivedId },
-          { ...movingPieceLoc,
-            timeline: existingBranchNode.timelineId as string,
+          { timeline: existingBranchNode.timelineId as string,
             turn: stabilizationStartTurn,
             region: action.to.region,
+            owner: movingPiece.owner,
+            type: movingPiece.type,
+            disambiguator: 0,
           },
         );
+        state.pieceStore.removePiece(state.gameId, movingPiece.id);
       }
       // Update the dest board's parties list
       const stabilizationStartTurn = originAddress.turn as Turn;

--- a/packages/engine/src/information-model.ts
+++ b/packages/engine/src/information-model.ts
@@ -47,25 +47,17 @@ export interface PlayerView {
 
 /**
  * Returns a view of the board for the given player — current state if party,
- * historical snapshot if non-party, or undefined if not visible at all.
+ * or undefined if not visible. Historical piece data is now in PieceStore
+ * (getHistoricalPieces), not in pluginData.
  */
 export function getBoardViewForPlayer(
   world: WorldState,
   branchId: BranchId,
   playerId: PlayerId,
 ): Board | undefined {
-  // Find the board on this timeline (stabilization start turn = any board on the timeline)
   for (const [, board] of world.boards) {
     if ((board.address.timeline as string) !== (branchId as string)) continue;
-
-    if (isParty(world, branchId, playerId)) {
-      return board;
-    }
-
-    const snapshot = board.pluginData['historicalSnapshot'];
-    if (snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)) {
-      return snapshot as Board;
-    }
+    if (isParty(world, branchId, playerId)) return board;
     return undefined;
   }
   return undefined;

--- a/packages/engine/src/world-state.ts
+++ b/packages/engine/src/world-state.ts
@@ -9,6 +9,8 @@ import {
   Economy,
   boardKey,
 } from '@5d/types';
+// Note: entity_upsert / entity_remove effects are removed. Piece mutations are
+// handled via PieceStore directly in game-loop.ts (Phase 3+).
 
 /** Returns the board at the given address, or undefined if it doesn't exist. */
 export function getBoardAt(world: WorldState, address: BoardAddress): Board | undefined {
@@ -26,19 +28,15 @@ export function setBoard(world: WorldState, board: Board): WorldState {
  * Applies the effects from an ActionResult to the given board.
  *
  * Well-known effect keys:
- *   entity_upsert  — { entity: Entity }  — add/update an entity on the board
- *   entity_remove  — { entityId: string } — remove an entity from the board
  *   region_update  — { region: RegionState } — update a region's state
- *   economy_update — { economy: Economy }   — update a player's economy
+ *   economy_update — { economy: Economy }    — update a player's economy
  *   plugin_data    — { key: string, value: unknown } — write into pluginData
+ *
+ * Piece mutations are handled directly via PieceStore in game-loop.ts.
  */
 export function applyActionResult(board: Board, result: ActionResult): Board {
   if (!result.success) return board;
 
-  // Phase 1 bridge: entity_upsert/entity_remove still operate on the runtime
-  // `entities` Map (not in the Board type). Phase 3 will remove this logic.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let entities: Map<any, any> = new Map((board as any).entities);
   let regions = new Map(board.regions);
   let economies = new Map(board.economies);
   let pluginData = { ...board.pluginData };
@@ -46,16 +44,7 @@ export function applyActionResult(board: Board, result: ActionResult): Board {
   for (const effect of result.effects) {
     const type = effect['type'] as string | undefined;
 
-    if (type === 'entity_upsert') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = effect['entity'] as any;
-      entities = new Map(entities);
-      entities.set(entity.id, entity);
-    } else if (type === 'entity_remove') {
-      const entityId = effect['entityId'] as string;
-      entities = new Map(entities);
-      entities.delete(entityId);
-    } else if (type === 'region_update') {
+    if (type === 'region_update') {
       const region = effect['region'] as RegionState;
       regions = new Map(regions);
       regions.set(region.id as RegionId, region);
@@ -69,8 +58,7 @@ export function applyActionResult(board: Board, result: ActionResult): Board {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { ...board, entities, regions, economies, pluginData } as any as Board;
+  return { ...board, regions, economies, pluginData };
 }
 
 /**

--- a/packages/stub/src/index.ts
+++ b/packages/stub/src/index.ts
@@ -86,11 +86,9 @@ const actionValidator: IActionValidator = {
     if (type === ('move' as typeof type)) {
       if (!entityId) return { valid: false, reason: 'move requires entityId' };
 
-      // Phase 1 bridge: runtime entities Map lives on board as untyped field
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { valid: false, reason: 'entity not found' };
-      if (entity.owner !== action.player) return { valid: false, reason: 'not your piece' };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { valid: false, reason: 'piece not found' };
+      if ((piece.owner as string) !== (action.player as string)) return { valid: false, reason: 'not your piece' };
       if (from.timeline !== to.timeline || from.turn !== to.turn) {
         return { valid: false, reason: 'move must stay on the same board' };
       }
@@ -104,10 +102,9 @@ const actionValidator: IActionValidator = {
 
     if (type === ('move_to_past' as typeof type)) {
       if (!entityId) return { valid: false, reason: 'move_to_past requires entityId' };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { valid: false, reason: 'entity not found' };
-      if (entity.owner !== action.player) return { valid: false, reason: 'not your piece' };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { valid: false, reason: 'piece not found' };
+      if ((piece.owner as string) !== (action.player as string)) return { valid: false, reason: 'not your piece' };
       if (to.turn >= from.turn) return { valid: false, reason: 'destination must be a past turn' };
       return { valid: true };
     }
@@ -129,20 +126,18 @@ const actionEvaluator: IActionEvaluator = {
     }
 
     if (type === ('move' as typeof type) && entityId) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entity = (context.board as any).entities?.get(entityId);
-      if (!entity) return { actionId: action.id, success: false, error: 'entity not found', effects: [] };
-
-      const moved = { ...entity, location: { ...action.to } };
-      return {
-        actionId: action.id,
-        success: true,
-        effects: [{ type: 'entity_upsert', entity: moved }],
-      };
+      const piece = context.board.pieces.find((p) => p.realPieceId === entityId);
+      if (!piece) return { actionId: action.id, success: false, error: 'piece not found', effects: [] };
+      // Spatial move: mutate store directly, engine handles board state
+      if (context.pieceStore) {
+        context.pieceStore.movePiece(context.gameId, entityId, { region: action.to.region });
+      }
+      return { actionId: action.id, success: true, effects: [] };
     }
 
-    if (type === ('move_to_past' as typeof type) && entityId) {
-      return { actionId: action.id, success: true, effects: [{ type: 'entity_remove', entityId }] };
+    if (type === ('move_to_past' as typeof type)) {
+      // Engine handles piece removal and branch bootstrap via pieceStore.createBranch()
+      return { actionId: action.id, success: true, effects: [] };
     }
 
     return { actionId: action.id, success: false, error: 'unknown action', effects: [] };

--- a/packages/types/src/game.ts
+++ b/packages/types/src/game.ts
@@ -50,6 +50,8 @@ export interface ActionContext {
    * Undefined until Phase 3 wires it in; plugins may guard with `if (context.pieceStore)`.
    */
   pieceStore: PieceStore | undefined;
+  /** Game ID for PieceStore calls. Populated from GameLoopState.gameId in buildContext. */
+  gameId: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/game.ts
+++ b/packages/types/src/game.ts
@@ -47,7 +47,7 @@ export interface ActionContext {
   halfActionBranchId: BranchId | undefined;
   /**
    * Piece store for direct mutations by the plugin evaluator.
-   * Undefined until Phase 3 wires it in; plugins may guard with `if (context.pieceStore)`.
+   * Undefined until Phase 4 wires the server; plugins may guard with `if (context.pieceStore)`.
    */
   pieceStore: PieceStore | undefined;
   /** Game ID for PieceStore calls. Populated from GameLoopState.gameId in buildContext. */


### PR DESCRIPTION
## Summary

- `buildContext` now populates `board.pieces` via `pieceStore.getPiecesOnBoard()` instead of empty array
- `processAction` captures moving piece via store; uses `pieceStore.addPiece()` for direct/subsequent arrivals; uses `pieceStore.createBranch()` for new branches (which handles source removal + history bootstrap)
- `advanceAllTimelines` delegates piece advancement to `pieceStore.advanceAllTimelines()`; removes Phase 1 entity bridge
- `applyActionResult` in `world-state.ts`: removes `entity_upsert`/`entity_remove` — piece mutations now handled entirely via PieceStore
- `information-model.ts`: removes `historicalSnapshot` pluginData read (historical data now in store)
- `GameLoopState` gains `gameId: string` + `pieceStore: PieceStore | undefined`; `ActionContext` gains `gameId: string`
- Test helpers: `MockPieceStore` (in-memory PieceStore for engine tests), updated `actionValidator`/`actionEvaluator` to use `board.pieces`, `makeState` accepts store, removes `makeEntity`/`EID`/entities bridge
- Rewrites `advance-timelines.test.ts` and `process-action.test.ts` with store-based assertions; updates `stabilization-enforcement.test.ts` to use `MockPieceStore`

## Test Plan

- [x] 72 engine tests pass (`pnpm --filter @5d/engine test`)
- [x] 48 server tests pass (`pnpm --filter @5d/server test`)
- [x] Full typecheck clean (`pnpm typecheck`)

Closes #38